### PR TITLE
Add admin views for registrations and payments

### DIFF
--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -8,6 +8,8 @@ from backend.routers.order import router as orders_router
 from backend.routers.paystack import router as paystack_router
 from backend.routers.admin_courses import router as admin_router
 from backend.routers.admin_customers import router as admin_customers_router
+from backend.routers.admin_registrations import router as admin_registrations_router
+from backend.routers.admin_payments import router as admin_payments_router
 
 # API Router for backend endpoints
 api_router = APIRouter()
@@ -20,6 +22,8 @@ api_router.include_router(paystack_router, tags=["paystack"])
 api_router.include_router(auth_router, prefix="/auth", tags=["paystack"])
 api_router.include_router(admin_router)
 api_router.include_router(admin_customers_router)
+api_router.include_router(admin_registrations_router)
+api_router.include_router(admin_payments_router)
 
 # Export both routers
 __all__ = ["api_router","pages_router"]

--- a/backend/routers/admin_payments.py
+++ b/backend/routers/admin_payments.py
@@ -1,0 +1,44 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.crud.payment import crud_payment
+from backend.models.user import User
+from backend.routers.auth import get_current_user
+
+router = APIRouter(prefix="/admin/payments", tags=["Admin Payments"])
+
+
+@router.get("/", response_model=List[dict])
+def list_payments(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    payments = crud_payment.get_all(db)
+    return [
+        {
+            "id": p.id,
+            "order_id": p.order_id,
+            "transaction_id": p.transaction_id,
+            "amount": p.amount,
+            "status": p.status,
+            "payment_date": p.payment_date,
+        }
+        for p in payments
+    ]
+
+
+@router.delete("/delete/{payment_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_payment(
+    payment_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    crud_payment.delete(db, payment_id)
+    return {"detail": f"Payment {payment_id} deleted"}

--- a/backend/routers/admin_registrations.py
+++ b/backend/routers/admin_registrations.py
@@ -1,0 +1,49 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.crud.registration import crud_registration
+from backend.models.payment import Payment
+from backend.models.user import User
+from backend.routers.auth import get_current_user
+
+router = APIRouter(prefix="/admin/registrations", tags=["Admin Registrations"])
+
+
+@router.get("/", response_model=List[dict])
+def list_registrations(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    regs = crud_registration.get_all(db)
+    result = []
+    for reg in regs:
+        payment = db.query(Payment).filter(Payment.order_id == reg.order_id).first()
+        result.append({
+            "id": reg.id,
+            "fullName": reg.fullName,
+            "phone": reg.phone,
+            "course_id": reg.course_id,
+            "order_id": reg.order_id,
+            "status": reg.status,
+            "is_verified": reg.is_verified,
+            "payment_status": payment.status if payment else "pending",
+            "registered_at": reg.registered_at,
+        })
+    return result
+
+
+@router.delete("/delete/{registration_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_registration(
+    registration_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    crud_registration.delete(db, registration_id)
+    return {"detail": f"Registration {registration_id} deleted"}

--- a/backend/routers/pages.py
+++ b/backend/routers/pages.py
@@ -3,9 +3,10 @@ from fastapi import APIRouter, HTTPException, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
-from backend.crud import crud_course, crud_registration, crud_order, crud_user
+from backend.crud import crud_course, crud_registration, crud_order, crud_user, crud_payment
 from backend.core.database import get_db
 from backend.models.user import User
+from backend.models.payment import Payment
 from backend.routers.auth import get_current_user
 
 router = APIRouter()
@@ -109,6 +110,34 @@ async def manage_courses_page(request: Request, user: User = Depends(get_current
         raise HTTPException(status_code=403, detail="Admin access required")
     courses = crud_course.get_all(db=db)
     return templates.TemplateResponse("admin/manage_courses.html", {"request": request, "courses": courses, "current_user": user})
+
+
+@router.get("/admin/manage-registrations", name="manage_registrations")
+async def manage_registrations_page(request: Request, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Render the 'Manage Registrations' page for admin."""
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    regs = crud_registration.get_all(db=db)
+    registrations = []
+    for reg in regs:
+        payment = db.query(Payment).filter(Payment.order_id == reg.order_id).first()
+        registrations.append({
+            "id": reg.id,
+            "fullName": reg.fullName,
+            "phone": reg.phone,
+            "course_id": reg.course_id,
+            "payment_status": payment.status if payment else "pending",
+        })
+    return templates.TemplateResponse("admin/manage_registrations.html", {"request": request, "registrations": registrations, "current_user": user})
+
+
+@router.get("/admin/manage-payments", name="manage_payments")
+async def manage_payments_page(request: Request, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Render the 'Manage Payments' page for admin."""
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    payments = crud_payment.get_all(db=db)
+    return templates.TemplateResponse("admin/manage_payments.html", {"request": request, "payments": payments, "current_user": user})
 
 
 @router.get("/admin/manage-customers", name="manage_customers")

--- a/frontend/static/js/pages/manage_payments.js
+++ b/frontend/static/js/pages/manage_payments.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const deleteButtons = document.querySelectorAll('.delete-payment');
+    deleteButtons.forEach(button => {
+        button.addEventListener('click', async (e) => {
+            e.preventDefault();
+            const paymentId = button.dataset.paymentId;
+            if (confirm('Are you sure you want to delete this payment?')) {
+                try {
+                    const res = await fetch(`/api/admin/payments/delete/${paymentId}`, { method: 'DELETE' });
+                    if (res.ok) {
+                        window.location.reload();
+                    } else {
+                        alert('Failed to delete payment.');
+                    }
+                } catch (err) {
+                    console.error('Error:', err);
+                    alert('An error occurred.');
+                }
+            }
+        });
+    });
+});

--- a/frontend/static/js/pages/manage_registrations.js
+++ b/frontend/static/js/pages/manage_registrations.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const deleteButtons = document.querySelectorAll('.delete-registration');
+    deleteButtons.forEach(button => {
+        button.addEventListener('click', async (e) => {
+            e.preventDefault();
+            const regId = button.dataset.regId;
+            if (confirm('Are you sure you want to delete this registration?')) {
+                try {
+                    const res = await fetch(`/api/admin/registrations/delete/${regId}`, { method: 'DELETE' });
+                    if (res.ok) {
+                        window.location.reload();
+                    } else {
+                        alert('Failed to delete registration.');
+                    }
+                } catch (err) {
+                    console.error('Error:', err);
+                    alert('An error occurred.');
+                }
+            }
+        });
+    });
+});

--- a/frontend/templates/admin/dashboard.html
+++ b/frontend/templates/admin/dashboard.html
@@ -28,9 +28,18 @@
         <div class="col-md-4">
             <div class="card">
                 <div class="card-body">
+                    <h5 class="card-title">Manage Registrations</h5>
+                    <p class="card-text">View course registrations and payments.</p>
+                    <a href="/admin/manage-registrations" class="btn btn-primary">Go to Registrations</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
                     <h5 class="card-title">Manage Payments</h5>
                     <p class="card-text">View and track payment information.</p>
-                    <a href="#" class="btn btn-primary">Go to Payments</a>
+                    <a href="/admin/manage-payments" class="btn btn-primary">Go to Payments</a>
                 </div>
             </div>
         </div>

--- a/frontend/templates/admin/manage_payments.html
+++ b/frontend/templates/admin/manage_payments.html
@@ -1,0 +1,37 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Manage Payments{% endblock %}
+{% block extra_head %}
+{{ super() }}
+<script src="/static/js/pages/manage_payments.js" defer></script>
+{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <h1>Manage Payments</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Transaction</th>
+                <th>Amount</th>
+                <th>Status</th>
+                <th>Date</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in payments %}
+            <tr>
+                <td>{{ p.transaction_id }}</td>
+                <td>{{ p.amount }}</td>
+                <td>{{ p.status }}</td>
+                <td>{{ p.payment_date }}</td>
+                <td>
+                    <a href="" class="btn btn-sm btn-danger delete-payment" data-payment-id="{{ p.id }}">Delete</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/frontend/templates/admin/manage_registrations.html
+++ b/frontend/templates/admin/manage_registrations.html
@@ -1,0 +1,37 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Manage Registrations{% endblock %}
+{% block extra_head %}
+{{ super() }}
+<script src="/static/js/pages/manage_registrations.js" defer></script>
+{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <h1>Manage Registrations</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Phone</th>
+                <th>Course ID</th>
+                <th>Payment Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for reg in registrations %}
+            <tr>
+                <td>{{ reg.fullName }}</td>
+                <td>{{ reg.phone }}</td>
+                <td>{{ reg.course_id }}</td>
+                <td>{{ reg.payment_status }}</td>
+                <td>
+                    <a href="" class="btn btn-sm btn-danger delete-registration" data-reg-id="{{ reg.id }}">Delete</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add routers to manage registrations and payments
- link new admin pages from dashboard
- create templates and JS for listing/deleting registrations and payments
- update pages router to render new admin pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684444fbd83c83328ffa6b5a3c73743f