### PR TITLE
Enhance admin views and customer management

### DIFF
--- a/backend/crud/user.py
+++ b/backend/crud/user.py
@@ -66,10 +66,9 @@ class CRUDUser:
 
         hashed_password = bcrypt.hash(obj_in.password)
         new_user = self.model(
-            username=obj_in.username,
             email=obj_in.email,
             password_hash=hashed_password,
-            role="student",
+            role=obj_in.role if obj_in.role else "student",
         )
         db.add(new_user)
         try:
@@ -117,8 +116,8 @@ class CRUDUser:
         if not user:
             raise HTTPException(status_code=404, detail=f"User with ID {user_id} not found.")
 
-        user.username = obj_in.username
         user.email = obj_in.email
+        user.role = obj_in.role if obj_in.role else user.role
         user.password_hash = bcrypt.hash(obj_in.password)
         db.add(user)
         try:

--- a/backend/routers/admin_customers.py
+++ b/backend/routers/admin_customers.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from backend.core.database import get_db
 from backend.crud.user import crud_user
 from backend.models.user import User
-from backend.pydanticschemas.user import UserResponse
+from backend.pydanticschemas.user import UserResponse, UserCreate
 from backend.routers.auth import get_current_user
 
 router = APIRouter(prefix="/admin/customers", tags=["Admin Customers"])
@@ -31,3 +31,15 @@ async def delete_customer(
         raise HTTPException(status_code=403, detail="Admin access required")
     crud_user.delete(db, user_id)
     return {"detail": f"User with ID {user_id} deleted."}
+
+
+@router.put("/{user_id}", response_model=UserResponse)
+async def update_customer(
+    user_id: int,
+    user_in: UserCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return crud_user.update(db, user_id, user_in)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -22,13 +22,13 @@ def test_get_users():
 def test_create_user():
     """Test creating a new user"""
     user_data = {
-        "username": "testuser",
         "email": "test@example.com",
-        "password": "password123"
+        "password": "password123",
+        "role": "student"
     }
     response = client.post("/users/", json=user_data)
     assert response.status_code == 201
-    assert response.json()["username"] == "testuser"
+    assert response.json()["email"] == "test@example.com"
 
 
 def test_get_courses():

--- a/frontend/static/js/pages/admin_edit_customer.js
+++ b/frontend/static/js/pages/admin_edit_customer.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('editCustomerForm');
+    const messageDiv = document.getElementById('editCustomerMessage');
+    const customerId = window.location.pathname.split('/').pop();
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const data = {
+            email: document.getElementById('email').value,
+            role: document.getElementById('role').value,
+            password: document.getElementById('password').value
+        };
+        try {
+            const response = await fetch(`/api/admin/customers/${customerId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            const resData = await response.json();
+            if (response.ok) {
+                messageDiv.innerHTML = '<div class="alert alert-success">Customer updated successfully.</div>';
+            } else {
+                messageDiv.innerHTML = `<div class="alert alert-danger">${resData.detail || 'Failed to update customer.'}</div>`;
+            }
+        } catch (err) {
+            console.error('Error:', err);
+            messageDiv.innerHTML = '<div class="alert alert-danger">An error occurred.</div>';
+        }
+    });
+});

--- a/frontend/templates/admin/admin_edit_customer.html
+++ b/frontend/templates/admin/admin_edit_customer.html
@@ -1,0 +1,34 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Edit Customer{% endblock %}
+{% block extra_head %}
+<script src="/static/js/pages/admin_edit_customer.js" defer></script>
+{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="card">
+        <div class="card-header">
+            <h1>Edit Customer</h1>
+        </div>
+        <div class="card-body">
+            <div id="editCustomerMessage" class="mb-3"></div>
+            <form id="editCustomerForm">
+                <div class="mb-3">
+                    <label for="email" class="form-label">Email</label>
+                    <input type="email" class="form-control" id="email" name="email" value="{{ customer.email }}" required>
+                </div>
+                <div class="mb-3">
+                    <label for="role" class="form-label">Role</label>
+                    <input type="text" class="form-control" id="role" name="role" value="{{ customer.role }}" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">New Password</label>
+                    <input type="password" class="form-control" id="password" name="password">
+                </div>
+                <button type="submit" class="btn btn-primary" id="editCustomerBtn">Update Customer</button>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/frontend/templates/admin/dashboard.html
+++ b/frontend/templates/admin/dashboard.html
@@ -6,7 +6,7 @@
 <div class="container mt-5">
     <h1>Admin Dashboard</h1>
     <p>Welcome, Admin!</p>
-    <div class="row">
+    <div class="row g-4">
         <div class="col-md-4">
             <div class="card">
                 <div class="card-body">

--- a/frontend/templates/admin/manage_customers.html
+++ b/frontend/templates/admin/manage_customers.html
@@ -23,6 +23,7 @@
                 <td>{{ customer.email }}</td>
                 <td>{{ customer.role }}</td>
                 <td>
+                    <a href="/admin/edit-customer/{{ customer.id }}" class="btn btn-sm btn-secondary">Edit</a>
                     <a href="" class="btn btn-sm btn-danger delete-customer" data-customer-id="{{ customer.id }}">Delete</a>
                 </td>
             </tr>

--- a/frontend/templates/admin/manage_payments.html
+++ b/frontend/templates/admin/manage_payments.html
@@ -14,6 +14,9 @@
             <tr>
                 <th>Transaction</th>
                 <th>Amount</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Courses</th>
                 <th>Status</th>
                 <th>Date</th>
                 <th>Actions</th>
@@ -24,6 +27,9 @@
             <tr>
                 <td>{{ p.transaction_id }}</td>
                 <td>{{ p.amount }}</td>
+                <td>{{ p.customer_name }}</td>
+                <td>{{ p.customer_email }}</td>
+                <td>{{ p.courses_count }}</td>
                 <td>{{ p.status }}</td>
                 <td>{{ p.payment_date }}</td>
                 <td>

--- a/frontend/templates/admin/manage_registrations.html
+++ b/frontend/templates/admin/manage_registrations.html
@@ -15,6 +15,7 @@
                 <th>Name</th>
                 <th>Phone</th>
                 <th>Course ID</th>
+                <th>Courses Registered</th>
                 <th>Payment Status</th>
                 <th>Actions</th>
             </tr>
@@ -25,8 +26,12 @@
                 <td>{{ reg.fullName }}</td>
                 <td>{{ reg.phone }}</td>
                 <td>{{ reg.course_id }}</td>
+                <td>{{ reg.courses_count }}</td>
                 <td>{{ reg.payment_status }}</td>
                 <td>
+                    {% if reg.payment_status == 'completed' %}
+                    <a href="/admin/manage-payments?order={{ reg.order_id }}" class="btn btn-sm btn-info">See Payment</a>
+                    {% endif %}
                     <a href="" class="btn btn-sm btn-danger delete-registration" data-reg-id="{{ reg.id }}">Delete</a>
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- show registration count and payment link on manage registrations
- display payer info and courses count on manage payments
- allow admin to edit customers and update credentials
- add edit customer page and JS handler
- space out admin dashboard cards
- adjust CRUD and routes for user updates
- update API tests for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844512f0c348332868892945a993354