### PR TITLE
Add pagination to admin pages

### DIFF
--- a/backend/routers/admin_customers.py
+++ b/backend/routers/admin_customers.py
@@ -13,12 +13,16 @@ router = APIRouter(prefix="/admin/customers", tags=["Admin Customers"])
 
 @router.get("/", response_model=List[UserResponse])
 async def list_customers(
+    page: int = 1,
+    limit: int = 10,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ):
+    """Return a paginated list of customers."""
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
-    return crud_user.get_all(db)
+    skip = (page - 1) * limit
+    return crud_user.get_all(db, skip=skip, limit=limit)
 
 
 @router.delete("/delete/{user_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routers/admin_payments.py
+++ b/backend/routers/admin_payments.py
@@ -13,12 +13,16 @@ router = APIRouter(prefix="/admin/payments", tags=["Admin Payments"])
 
 @router.get("/", response_model=List[dict])
 def list_payments(
+    page: int = 1,
+    limit: int = 10,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    """Return a paginated list of payments."""
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
-    payments = crud_payment.get_all(db)
+    skip = (page - 1) * limit
+    payments = crud_payment.get_all(db, skip=skip, limit=limit)
     return [
         {
             "id": p.id,

--- a/backend/routers/admin_registrations.py
+++ b/backend/routers/admin_registrations.py
@@ -14,12 +14,16 @@ router = APIRouter(prefix="/admin/registrations", tags=["Admin Registrations"])
 
 @router.get("/", response_model=List[dict])
 def list_registrations(
+    page: int = 1,
+    limit: int = 10,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    """Return a paginated list of registrations."""
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
-    regs = crud_registration.get_all(db)
+    skip = (page - 1) * limit
+    regs = crud_registration.get_all(db, skip=skip, limit=limit)
     result = []
     for reg in regs:
         payment = db.query(Payment).filter(Payment.order_id == reg.order_id).first()

--- a/frontend/templates/admin/manage_courses.html
+++ b/frontend/templates/admin/manage_courses.html
@@ -31,6 +31,21 @@
             {% endfor %}
         </tbody>
     </table>
+    <nav aria-label="Course pagination">
+        <ul class="pagination">
+            {% if page > 1 %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% if has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
     <a href="/admin/add-course" class="btn btn-success">Add Course</a>
 </div>
 {% endblock %}

--- a/frontend/templates/admin/manage_customers.html
+++ b/frontend/templates/admin/manage_customers.html
@@ -30,5 +30,20 @@
             {% endfor %}
         </tbody>
     </table>
+    <nav aria-label="Customer pagination">
+        <ul class="pagination">
+            {% if page > 1 %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% if has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/frontend/templates/admin/manage_payments.html
+++ b/frontend/templates/admin/manage_payments.html
@@ -39,5 +39,20 @@
             {% endfor %}
         </tbody>
     </table>
+    <nav aria-label="Payment pagination">
+        <ul class="pagination">
+            {% if page > 1 %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% if has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/frontend/templates/admin/manage_registrations.html
+++ b/frontend/templates/admin/manage_registrations.html
@@ -38,5 +38,20 @@
             {% endfor %}
         </tbody>
     </table>
+    <nav aria-label="Registration pagination">
+        <ul class="pagination">
+            {% if page > 1 %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% if has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add page and limit query params to admin API routes
- paginate admin dashboard templates and backend routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684457544dc4833299680714eeeaa0fc