### PR TITLE
Add view customer courses page for admin

### DIFF
--- a/backend/routers/admin_registrations.py
+++ b/backend/routers/admin_registrations.py
@@ -31,6 +31,7 @@ def list_registrations(
             "id": reg.id,
             "fullName": reg.fullName,
             "phone": reg.phone,
+            "user_id": reg.user_id,
             "course_id": reg.course_id,
             "order_id": reg.order_id,
             "status": reg.status,

--- a/frontend/templates/admin/customer_courses.html
+++ b/frontend/templates/admin/customer_courses.html
@@ -1,0 +1,31 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Customer Courses{% endblock %}
+{% block content %}
+<div class="container mt-5">
+    <h1>Courses for {{ customer.email }}</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Course Name</th>
+                <th>Course ID</th>
+                <th>Date Registered</th>
+                <th>Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in courses %}
+            <tr>
+                <td>{{ c.name }}</td>
+                <td>{{ c.course_id }}</td>
+                <td>{{ c.registered_at }}</td>
+                <td>{{ c.price }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <div class="text-end fw-bold">
+        Total Amount: {{ total_amount }}
+    </div>
+</div>
+{% endblock %}

--- a/frontend/templates/admin/manage_registrations.html
+++ b/frontend/templates/admin/manage_registrations.html
@@ -29,6 +29,7 @@
                 <td>{{ reg.courses_count }}</td>
                 <td>{{ reg.payment_status }}</td>
                 <td>
+                    <a href="/admin/customer-courses/{{ reg.user_id }}" class="btn btn-sm btn-secondary">See Courses</a>
                     {% if reg.payment_status == 'completed' %}
                     <a href="/admin/manage-payments?order={{ reg.order_id }}" class="btn btn-sm btn-info">See Payment</a>
                     {% endif %}


### PR DESCRIPTION
## Summary
- include user_id in admin registration data
- add 'See Courses' action button on Manage Registrations
- implement new `/admin/customer-courses/{user_id}` page to list courses a customer registered for
- create template to display course name, ID, date, amount, and total

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445bee3d1883329283256114d091d8