### PR TITLE
Add admin search and cookie consent

### DIFF
--- a/backend/routers/admin_customers.py
+++ b/backend/routers/admin_customers.py
@@ -15,6 +15,7 @@ router = APIRouter(prefix="/admin/customers", tags=["Admin Customers"])
 async def list_customers(
     page: int = 1,
     limit: int = 10,
+    search: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -22,7 +23,10 @@ async def list_customers(
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
     skip = (page - 1) * limit
-    return crud_user.get_all(db, skip=skip, limit=limit)
+    query = db.query(User)
+    if search:
+        query = query.filter(User.email.ilike(f"%{search}%"))
+    return query.offset(skip).limit(limit).all()
 
 
 @router.delete("/delete/{user_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routers/admin_payments.py
+++ b/backend/routers/admin_payments.py
@@ -15,6 +15,7 @@ router = APIRouter(prefix="/admin/payments", tags=["Admin Payments"])
 def list_payments(
     page: int = 1,
     limit: int = 10,
+    search: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -22,7 +23,10 @@ def list_payments(
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
     skip = (page - 1) * limit
-    payments = crud_payment.get_all(db, skip=skip, limit=limit)
+    query = db.query(crud_payment.model)
+    if search:
+        query = query.filter(crud_payment.model.transaction_id.ilike(f"%{search}%"))
+    payments = query.offset(skip).limit(limit).all()
     return [
         {
             "id": p.id,

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -112,4 +112,15 @@ body {
   .contact-link {
     color: #fff;
     text-decoration: underline;
-  }  
+  }
+
+/* Cookie consent banner */
+#cookie-consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #f8f9fa;
+  border-top: 1px solid #ccc;
+  display: none;
+}

--- a/frontend/static/js/components/cookie_consent.js
+++ b/frontend/static/js/components/cookie_consent.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const banner = document.getElementById('cookie-consent');
+    if (!banner) return;
+    if (!localStorage.getItem('cookie_consent')) {
+        banner.style.display = 'block';
+    }
+    const btn = document.getElementById('cookie-consent-accept');
+    if (btn) {
+        btn.addEventListener('click', () => {
+            localStorage.setItem('cookie_consent', 'true');
+            banner.remove();
+        });
+    }
+});

--- a/frontend/templates/admin/manage_courses.html
+++ b/frontend/templates/admin/manage_courses.html
@@ -8,6 +8,11 @@
 {% block content %}
 <div class="container mt-5">
     <h1>Manage Courses</h1>
+    <form method="get" class="d-flex mb-3">
+        <input type="text" name="search" class="form-control me-2" placeholder="Search" value="{{ search or '' }}">
+        <input type="hidden" name="limit" value="{{ limit }}">
+        <button class="btn btn-outline-secondary" type="submit">Search</button>
+    </form>
     <table class="table">
         <thead>
             <tr>
@@ -35,13 +40,17 @@
         <ul class="pagination">
             {% if page > 1 %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}&search={{ search }}">Previous</a>
             </li>
             {% endif %}
-            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% for p in pages %}
+            <li class="page-item {% if p == page %}active{% endif %}">
+                <a class="page-link" href="?page={{ p }}&limit={{ limit }}&search={{ search }}">{{ p }}</a>
+            </li>
+            {% endfor %}
             {% if has_next %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}&search={{ search }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/frontend/templates/admin/manage_customers.html
+++ b/frontend/templates/admin/manage_customers.html
@@ -9,6 +9,11 @@
 {% block content %}
 <div class="container mt-5">
     <h1>Manage Customers</h1>
+    <form method="get" class="d-flex mb-3">
+        <input type="text" name="search" class="form-control me-2" placeholder="Search" value="{{ search or '' }}">
+        <input type="hidden" name="limit" value="{{ limit }}">
+        <button class="btn btn-outline-secondary" type="submit">Search</button>
+    </form>
     <table class="table">
         <thead>
             <tr>
@@ -34,13 +39,17 @@
         <ul class="pagination">
             {% if page > 1 %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}&search={{ search }}">Previous</a>
             </li>
             {% endif %}
-            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% for p in pages %}
+            <li class="page-item {% if p == page %}active{% endif %}">
+                <a class="page-link" href="?page={{ p }}&limit={{ limit }}&search={{ search }}">{{ p }}</a>
+            </li>
+            {% endfor %}
             {% if has_next %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}&search={{ search }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/frontend/templates/admin/manage_payments.html
+++ b/frontend/templates/admin/manage_payments.html
@@ -9,6 +9,14 @@
 {% block content %}
 <div class="container mt-5">
     <h1>Manage Payments</h1>
+    <form method="get" class="d-flex mb-3">
+        {% if order %}
+        <input type="hidden" name="order" value="{{ order }}">
+        {% endif %}
+        <input type="text" name="search" class="form-control me-2" placeholder="Search" value="{{ search or '' }}">
+        <input type="hidden" name="limit" value="{{ limit }}">
+        <button class="btn btn-outline-secondary" type="submit">Search</button>
+    </form>
     <table class="table">
         <thead>
             <tr>
@@ -43,13 +51,17 @@
         <ul class="pagination">
             {% if page > 1 %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}&search={{ search }}{% if order %}&order={{ order }}{% endif %}">Previous</a>
             </li>
             {% endif %}
-            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% for p in pages %}
+            <li class="page-item {% if p == page %}active{% endif %}">
+                <a class="page-link" href="?page={{ p }}&limit={{ limit }}&search={{ search }}{% if order %}&order={{ order }}{% endif %}">{{ p }}</a>
+            </li>
+            {% endfor %}
             {% if has_next %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}&search={{ search }}{% if order %}&order={{ order }}{% endif %}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/frontend/templates/admin/manage_registrations.html
+++ b/frontend/templates/admin/manage_registrations.html
@@ -9,6 +9,11 @@
 {% block content %}
 <div class="container mt-5">
     <h1>Manage Registrations</h1>
+    <form method="get" class="d-flex mb-3">
+        <input type="text" name="search" class="form-control me-2" placeholder="Search" value="{{ search or '' }}">
+        <input type="hidden" name="limit" value="{{ limit }}">
+        <button class="btn btn-outline-secondary" type="submit">Search</button>
+    </form>
     <table class="table">
         <thead>
             <tr>
@@ -43,13 +48,17 @@
         <ul class="pagination">
             {% if page > 1 %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}">Previous</a>
+                <a class="page-link" href="?page={{ page - 1 }}&limit={{ limit }}&search={{ search }}">Previous</a>
             </li>
             {% endif %}
-            <li class="page-item disabled"><span class="page-link">{{ page }}</span></li>
+            {% for p in pages %}
+            <li class="page-item {% if p == page %}active{% endif %}">
+                <a class="page-link" href="?page={{ p }}&limit={{ limit }}&search={{ search }}">{{ p }}</a>
+            </li>
+            {% endfor %}
             {% if has_next %}
             <li class="page-item">
-                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}">Next</a>
+                <a class="page-link" href="?page={{ page + 1 }}&limit={{ limit }}&search={{ search }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/frontend/templates/layout/base.html
+++ b/frontend/templates/layout/base.html
@@ -50,6 +50,13 @@
     {% block content %}{% endblock %}
   </main>
 
+  <div id="cookie-consent" class="py-3">
+    <div class="container d-flex justify-content-between align-items-center">
+      <span>We use cookies to improve your experience. By using our site, you consent to cookies.</span>
+      <button id="cookie-consent-accept" class="btn btn-primary btn-sm">Accept</button>
+    </div>
+  </div>
+
   <!-- Footer (if you have one) -->
   {% include 'partials/footer.html' %}
 
@@ -61,6 +68,7 @@
   ></script>
   <script src="/static/js/components/footer.js">
   </script>
+  <script src="/static/js/components/cookie_consent.js" defer></script>
   {% block extra_scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable search and multi-page navigation on admin pages
- implement search in admin API routes
- add cookie consent banner with JS logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b6f35bd08332824f21966b131af6