### PR TITLE
Remove course id from registrations page and add placeholder social media page

### DIFF
--- a/backend/routers/pages.py
+++ b/backend/routers/pages.py
@@ -184,7 +184,6 @@ async def manage_registrations_page(
                 "fullName": reg.fullName,
                 "phone": reg.phone,
                 "user_id": reg.user_id,
-                "course_id": reg.course_id,
                 "order_id": reg.order_id,
                 "courses_count": courses_count,
                 "payment_status": payment.status if payment else "pending",
@@ -399,6 +398,20 @@ async def edit_customer_page(
     return templates.TemplateResponse(
         "admin/admin_edit_customer.html",
         {"request": request, "customer": customer, "current_user": user},
+    )
+
+
+@router.get("/admin/social-media", name="social_media")
+async def social_media_page(
+    request: Request,
+    user: User = Depends(get_current_user),
+):
+    """Render the Social Media Management page."""
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return templates.TemplateResponse(
+        "admin/social_media.html",
+        {"request": request, "current_user": user},
     )
 
 @router.get("/admin/coming_soon", response_class=HTMLResponse)

--- a/frontend/templates/admin/dashboard.html
+++ b/frontend/templates/admin/dashboard.html
@@ -43,6 +43,15 @@
                 </div>
             </div>
         </div>
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Social Media</h5>
+                    <p class="card-text">Control company social media accounts.</p>
+                    <a href="/admin/social-media" class="btn btn-primary">Open Social Media</a>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/frontend/templates/admin/manage_registrations.html
+++ b/frontend/templates/admin/manage_registrations.html
@@ -19,7 +19,6 @@
             <tr>
                 <th>Name</th>
                 <th>Phone</th>
-                <th>Course ID</th>
                 <th>Courses Registered</th>
                 <th>Payment Status</th>
                 <th>Actions</th>
@@ -30,7 +29,6 @@
             <tr>
                 <td>{{ reg.fullName }}</td>
                 <td>{{ reg.phone }}</td>
-                <td>{{ reg.course_id }}</td>
                 <td>{{ reg.courses_count }}</td>
                 <td>{{ reg.payment_status }}</td>
                 <td>

--- a/frontend/templates/admin/social_media.html
+++ b/frontend/templates/admin/social_media.html
@@ -1,0 +1,13 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Social Media Management{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <h1>Social Media Management</h1>
+    <p>This feature will allow administrators to post updates, view comments and messages,
+        and track likes and followers from a single dashboard. Integration with external
+        social media platforms is currently under development.</p>
+    <a class="btn btn-primary" href="/admin/dashboard">Back to Dashboard</a>
+</div>
+{% endblock %}

--- a/frontend/templates/partials/admin/admin_navbar.html
+++ b/frontend/templates/partials/admin/admin_navbar.html
@@ -51,6 +51,7 @@
           <li class="nav-item"><a class="nav-link" href="/admin/coming_soon">Users</a></li>
           <li class="nav-item"><a class="nav-link" href="/admin/coming_soon">Registrations</a></li>
           <li class="nav-item"><a class="nav-link" href="/admin/add-course">Create Course</a></li>
+          <li class="nav-item"><a class="nav-link" href="/admin/social-media">Social Media</a></li>
         </ul>
   
         <ul class="navbar-nav ms-auto">


### PR DESCRIPTION
## Summary
- remove unused course ID column on manage registrations page
- adjust backend response accordingly
- add new Social Media page and admin route
- link to the new page from dashboard and admin navbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c028412c8332b8f1dfb40ed85c5e