### PR TITLE
Implement basic post scheduling

### DIFF
--- a/alembic/versions/0b8d63f18eb1_add_social_post_schedule.py
+++ b/alembic/versions/0b8d63f18eb1_add_social_post_schedule.py
@@ -1,0 +1,33 @@
+"""add social media post schedule
+
+Revision ID: 0b8d63f18eb1
+Revises: d3e7e614a003
+Create Date: 2025-06-08 00:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '0b8d63f18eb1'
+down_revision: Union[str, None] = 'd3e7e614a003'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'social_media_posts',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('platform', sa.String(length=50), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('scheduled_at', sa.DateTime(), nullable=True),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default='draft'),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.text('now()')),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_social_media_posts_id'), 'social_media_posts', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_social_media_posts_id'), table_name='social_media_posts')
+    op.drop_table('social_media_posts')

--- a/backend/crud/__init__.py
+++ b/backend/crud/__init__.py
@@ -3,6 +3,7 @@ from backend.crud.registration import crud_registration
 from backend.crud.payment import crud_payment
 from backend.crud.user import crud_user
 from backend.crud.order import crud_order
+from backend.crud.social_post import crud_social_post
 
 __all__ = [
     "crud_course",
@@ -10,4 +11,6 @@ __all__ = [
     "crud_payment",
     "crud_user",
     "crud_order"
+    ,"crud_social_post"
 ]
+

--- a/backend/crud/social_post.py
+++ b/backend/crud/social_post.py
@@ -1,0 +1,41 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+from typing import List, Optional
+
+from backend.models.social_post import SocialMediaPost
+from backend.pydanticschemas.social_post import SocialMediaPostCreate
+
+class CRUDSocialPost:
+    def __init__(self, model):
+        self.model = model
+
+    def create(self, db: Session, obj_in: SocialMediaPostCreate) -> SocialMediaPost:
+        post = self.model(**obj_in.model_dump())
+        db.add(post)
+        try:
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))
+        db.refresh(post)
+        return post
+
+    def get_all(self, db: Session, skip: int = 0, limit: int = 100) -> List[SocialMediaPost]:
+        query = db.query(self.model)
+        query = query.order_by(self.model.scheduled_at.is_(None), self.model.scheduled_at, self.model.created_at.desc())
+        return query.offset(skip).limit(limit).all()
+
+    def delete(self, db: Session, post_id: int) -> Optional[SocialMediaPost]:
+        post = db.query(self.model).filter(self.model.id == post_id).first()
+        if not post:
+            raise HTTPException(status_code=404, detail="Post not found")
+        db.delete(post)
+        try:
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))
+        return post
+
+crud_social_post = CRUDSocialPost(SocialMediaPost)
+

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -5,3 +5,5 @@ from backend.models.registration import Registration
 from backend.models.payment import Payment
 from backend.models.order import Order
 from backend.models.blacklisted_tokens import BlacklistedToken
+from backend.models.social_post import SocialMediaPost
+

--- a/backend/models/social_post.py
+++ b/backend/models/social_post.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from backend.core.database import Base
+
+class SocialMediaPost(Base):
+    __tablename__ = "social_media_posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    platform = Column(String(50), nullable=False)
+    content = Column(Text, nullable=False)
+    scheduled_at = Column(DateTime, nullable=True)
+    status = Column(String(20), nullable=False, default="draft")
+    created_at = Column(DateTime, default=datetime.utcnow)
+

--- a/backend/pydanticschemas/social_post.py
+++ b/backend/pydanticschemas/social_post.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+class SocialMediaPostBase(BaseModel):
+    platform: str = Field(..., max_length=50)
+    content: str
+    scheduled_at: datetime | None = None
+    status: str = "draft"
+
+class SocialMediaPostCreate(SocialMediaPostBase):
+    pass
+
+class SocialMediaPostSchema(SocialMediaPostBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -10,6 +10,7 @@ from backend.routers.admin_courses import router as admin_router
 from backend.routers.admin_customers import router as admin_customers_router
 from backend.routers.admin_registrations import router as admin_registrations_router
 from backend.routers.admin_payments import router as admin_payments_router
+from backend.routers.social_media import router as social_media_router
 
 # API Router for backend endpoints
 api_router = APIRouter()
@@ -24,6 +25,8 @@ api_router.include_router(admin_router)
 api_router.include_router(admin_customers_router)
 api_router.include_router(admin_registrations_router)
 api_router.include_router(admin_payments_router)
+api_router.include_router(social_media_router)
 
 # Export both routers
 __all__ = ["api_router","pages_router"]
+

--- a/backend/routers/pages.py
+++ b/backend/routers/pages.py
@@ -11,6 +11,7 @@ from backend.models.payment import Payment
 from backend.models.registration import Registration
 from backend.models.order import Order
 from backend.models.course import Course
+from backend.crud.social_post import crud_social_post
 from backend.routers.auth import get_current_user
 
 router = APIRouter()
@@ -405,13 +406,15 @@ async def edit_customer_page(
 async def social_media_page(
     request: Request,
     user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
     """Render the Social Media Management page."""
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
+    posts = crud_social_post.get_all(db)
     return templates.TemplateResponse(
         "admin/social_media.html",
-        {"request": request, "current_user": user},
+        {"request": request, "current_user": user, "posts": posts},
     )
 
 @router.get("/admin/coming_soon", response_class=HTMLResponse)

--- a/backend/routers/social_media.py
+++ b/backend/routers/social_media.py
@@ -1,0 +1,31 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.crud.social_post import crud_social_post
+from backend.models.user import User
+from backend.pydanticschemas.social_post import SocialMediaPostCreate, SocialMediaPostSchema
+from backend.routers.auth import get_current_user
+
+router = APIRouter(prefix="/admin/social-posts", tags=["Social Media"])
+
+@router.get("/", response_model=List[SocialMediaPostSchema])
+async def list_posts(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return crud_social_post.get_all(db)
+
+@router.post("/", response_model=SocialMediaPostSchema, status_code=status.HTTP_201_CREATED)
+async def create_post(post_in: SocialMediaPostCreate, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return crud_social_post.create(db, post_in)
+
+@router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_post(post_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    crud_social_post.delete(db, post_id)
+    return {"detail": f"Post {post_id} deleted"}
+

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -53,3 +53,28 @@ def test_create_course():
     assert response.status_code == 201
     assert response.json()["title"] == "AI for Kids"
 
+
+def test_social_media_posts():
+    """Test listing social media posts."""
+    response = client.get("/admin/social-posts/")
+    assert response.status_code in (200, 403, 401)
+
+
+def test_create_social_media_post():
+    """Test creating a social media post."""
+    data = {"platform": "twitter", "content": "Hello"}
+    response = client.post("/admin/social-posts/", json=data)
+    assert response.status_code in (201, 403, 401)
+
+
+def test_create_scheduled_post():
+    """Test creating a scheduled post."""
+    data = {
+        "platform": "facebook",
+        "content": "Scheduled",
+        "scheduled_at": "2030-01-01T10:00:00",
+    }
+    response = client.post("/admin/social-posts/", json=data)
+    assert response.status_code in (201, 403, 401)
+
+

--- a/frontend/static/js/pages/social_media.js
+++ b/frontend/static/js/pages/social_media.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('post-form');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(form);
+        const data = {
+            platform: formData.get('platform'),
+            content: formData.get('content'),
+            scheduled_at: formData.get('scheduled_at') || null,
+        };
+        const res = await fetch('/api/admin/social-posts/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        if (res.ok) {
+            window.location.reload();
+        } else {
+            alert('Failed to create post');
+        }
+    });
+
+    document.querySelectorAll('.delete-post').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+            e.preventDefault();
+            const id = btn.dataset.postId;
+            if (confirm('Delete this post?')) {
+                const res = await fetch(`/api/admin/social-posts/${id}`, { method: 'DELETE' });
+                if (res.ok) {
+                    window.location.reload();
+                } else {
+                    alert('Failed to delete post');
+                }
+            }
+        });
+    });
+});
+

--- a/frontend/templates/admin/social_media.html
+++ b/frontend/templates/admin/social_media.html
@@ -1,13 +1,56 @@
 {% extends "layout/base.html" %}
 
 {% block title %}Social Media Management{% endblock %}
+{% block extra_head %}
+{{ super() }}
+<script src="/static/js/pages/social_media.js" defer></script>
+{% endblock %}
 
 {% block content %}
 <div class="container mt-5">
     <h1>Social Media Management</h1>
-    <p>This feature will allow administrators to post updates, view comments and messages,
-        and track likes and followers from a single dashboard. Integration with external
-        social media platforms is currently under development.</p>
+    <form id="post-form" class="mb-4">
+        <div class="mb-3">
+            <label class="form-label">Platform</label>
+            <input type="text" name="platform" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Content</label>
+            <textarea name="content" class="form-control" rows="3" required></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Schedule Time</label>
+            <input type="datetime-local" name="scheduled_at" class="form-control">
+        </div>
+        <button type="submit" class="btn btn-success">Create Post</button>
+    </form>
+
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Platform</th>
+                <th>Content</th>
+                <th>Scheduled</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in posts %}
+            <tr>
+                <td>{{ p.platform }}</td>
+                <td>{{ p.content }}</td>
+                <td>{{ p.scheduled_at.strftime('%Y-%m-%d %H:%M') if p.scheduled_at else '-' }}</td>
+                <td>{{ p.status }}</td>
+                <td>{{ p.created_at.strftime('%Y-%m-%d') }}</td>
+                <td>
+                    <a href="" class="btn btn-sm btn-danger delete-post" data-post-id="{{ p.id }}">Delete</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
     <a class="btn btn-primary" href="/admin/dashboard">Back to Dashboard</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow scheduling for social posts
- store schedule and status columns
- order posts by schedule time
- show scheduling fields in UI
- add Alembic migration for social posts table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c2b3b0ec8332b9a2d093c2e46392