### PR TITLE
Add scheduler for social media posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# TechKids
+
+This project powers the TechKids API and website. A background scheduler
+periodically publishes `SocialMediaPost` entries when they become due.
+
+## Running the Scheduler
+
+The scheduler starts automatically with the FastAPI application. It checks for
+social media posts whose `scheduled_at` time is in the past and whose status is
+`draft`. After attempting to publish the post, the status is updated to either
+`posted` or `failed`.
+
+Environment variables control the scheduler behaviour and API credentials. The
+most important ones are:
+
+- `POST_SCHEDULER_INTERVAL` – interval in seconds between checks (default `60`).
+- `FACEBOOK_API_TOKEN`, `X_API_TOKEN`, `INSTAGRAM_API_TOKEN` – credentials used
+  by the placeholder posting functions.
+
+Simply run the FastAPI app as usual (for example with `uvicorn main:app`) and
+the scheduler will run in the background.

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     EMAIL_SENDER: str
     EMAIL_HOST: str
     EMAIL_PORT: int
+    POST_SCHEDULER_INTERVAL: int = 60
+    FACEBOOK_API_TOKEN: str | None = None
+    X_API_TOKEN: str | None = None
+    INSTAGRAM_API_TOKEN: str | None = None
     # If you have more config variables, add them here.
 
     # Pydantic 2.x style config

--- a/backend/services/social_scheduler.py
+++ b/backend/services/social_scheduler.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+from typing import Callable, Dict
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from backend.core.config import settings
+from backend.core.database import SessionLocal
+from backend.models.social_post import SocialMediaPost
+
+
+# Placeholder posting functions ---------------------------------------------
+
+def post_to_facebook(post: SocialMediaPost) -> None:
+    """Simulate sending a post to Facebook API."""
+    # Here you would use settings.FACEBOOK_API_TOKEN etc.
+    print(f"Posting to Facebook: {post.content}")
+
+
+def post_to_x(post: SocialMediaPost) -> None:
+    """Simulate sending a post to X/Twitter API."""
+    print(f"Posting to X: {post.content}")
+
+
+def post_to_instagram(post: SocialMediaPost) -> None:
+    """Simulate sending a post to Instagram API."""
+    print(f"Posting to Instagram: {post.content}")
+
+
+PLATFORM_HANDLERS: Dict[str, Callable[[SocialMediaPost], None]] = {
+    "facebook": post_to_facebook,
+    "x": post_to_x,
+    "twitter": post_to_x,
+    "instagram": post_to_instagram,
+}
+
+
+# Core dispatch logic --------------------------------------------------------
+
+def _send_post(post: SocialMediaPost) -> bool:
+    handler = PLATFORM_HANDLERS.get(post.platform.lower())
+    if not handler:
+        return False
+    try:
+        handler(post)
+        return True
+    except Exception:
+        return False
+
+
+def dispatch_due_posts() -> None:
+    """Publish all due posts and update their status."""
+    db = SessionLocal()
+    try:
+        now = datetime.utcnow()
+        due_posts = (
+            db.query(SocialMediaPost)
+            .filter(SocialMediaPost.status == "draft")
+            .filter(SocialMediaPost.scheduled_at <= now)
+            .all()
+        )
+        for post in due_posts:
+            success = _send_post(post)
+            post.status = "posted" if success else "failed"
+            db.add(post)
+        if due_posts:
+            db.commit()
+    finally:
+        db.close()
+
+
+_scheduler: BackgroundScheduler | None = None
+
+def start_scheduler() -> None:
+    """Start the background scheduler if not already running."""
+    global _scheduler
+    if _scheduler:
+        return
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(
+        dispatch_due_posts,
+        IntervalTrigger(seconds=settings.POST_SCHEDULER_INTERVAL),
+    )
+    scheduler.start()
+    _scheduler = scheduler

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,51 @@
+import datetime
+import pytest
+
+try:
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+except ModuleNotFoundError:
+    pytest.skip("sqlalchemy is required", allow_module_level=True)
+
+from backend.models.social_post import SocialMediaPost
+from backend.core.database import Base
+from backend.services import social_scheduler
+
+
+def setup_in_memory_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return engine, TestingSessionLocal
+
+
+def test_dispatch_due_posts(monkeypatch):
+    engine, TestSession = setup_in_memory_db()
+    monkeypatch.setattr(social_scheduler, "SessionLocal", TestSession)
+
+    sent = []
+
+    def fake_handler(post):
+        sent.append(post.id)
+
+    social_scheduler.PLATFORM_HANDLERS["facebook"] = fake_handler
+
+    db = TestSession()
+    post = SocialMediaPost(
+        platform="facebook",
+        content="hello",
+        content_type="feed",
+        scheduled_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=1),
+        status="draft",
+    )
+    db.add(post)
+    db.commit()
+
+    social_scheduler.dispatch_due_posts()
+
+    db.refresh(post)
+    assert post.status == "posted"
+    assert sent == [post.id]
+
+    db.close()
+    engine.dispose()

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import uvicorn
 import uvicorn
 from backend.middleware import blacklist_middleware
 from backend.routers import api_router, pages_router
+from backend.services.social_scheduler import start_scheduler
 
 logging.basicConfig(
     level=logging.INFO,
@@ -64,6 +65,12 @@ app.include_router(api_router, prefix="/api")
 
 # Include the pages router for frontend routes
 app.include_router(pages_router)
+
+
+@app.on_event("startup")
+def start_background_tasks() -> None:
+    """Start recurring schedulers."""
+    start_scheduler()
 
 
 

--- a/requirements
+++ b/requirements
@@ -45,3 +45,4 @@ SQLAlchemy==2.0.37
 starlette==0.45.3
 typing_extensions==4.12.2
 uvicorn==0.34.0
+APScheduler==3.10.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ starlette==0.45.3
 typing_extensions==4.12.2
 urllib3==2.3.0
 uvicorn==0.34.0
+APScheduler==3.10.4


### PR DESCRIPTION
## Summary
- implement `social_scheduler` with APScheduler
- configure scheduler interval and tokens
- run scheduler on FastAPI startup
- add dependency to requirements
- create scheduler tests
- document scheduler usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ce2812a88332a05101011468d074