### PR TITLE
Add teach-with-us application and policy pages

### DIFF
--- a/backend/crud/teacher_application.py
+++ b/backend/crud/teacher_application.py
@@ -1,0 +1,17 @@
+from sqlalchemy.orm import Session
+from backend.models.teacher_application import TeacherApplication
+from backend.pydanticschemas.teacher_application import TeacherApplicationCreate
+
+class CRUDTeacherApplication:
+    def __init__(self, model):
+        self.model = model
+
+    def create(self, db: Session, obj_in: TeacherApplicationCreate) -> TeacherApplication:
+        data = obj_in.model_dump()
+        record = self.model(**data)
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        return record
+
+crud_teacher_application = CRUDTeacherApplication(TeacherApplication)

--- a/backend/models/teacher_application.py
+++ b/backend/models/teacher_application.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from datetime import datetime
+from backend.core.database import Base
+
+class TeacherApplication(Base):
+    __tablename__ = "teacher_applications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    full_name = Column(String(100), nullable=False)
+    email = Column(String(100), nullable=False)
+    phone = Column(String(20), nullable=True)
+    message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<TeacherApplication(id={self.id}, email={self.email})>"

--- a/backend/pydanticschemas/teacher_application.py
+++ b/backend/pydanticschemas/teacher_application.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+
+class TeacherApplicationCreate(BaseModel):
+    full_name: str
+    email: EmailStr
+    phone: Optional[str] = None
+    message: Optional[str] = None

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -11,6 +11,7 @@ from backend.routers.admin_customers import router as admin_customers_router
 from backend.routers.admin_registrations import router as admin_registrations_router
 from backend.routers.admin_payments import router as admin_payments_router
 from backend.routers.social_media import router as social_media_router
+from backend.routers.teacher_application import router as teacher_app_router
 
 # API Router for backend endpoints
 api_router = APIRouter()
@@ -26,6 +27,7 @@ api_router.include_router(admin_customers_router)
 api_router.include_router(admin_registrations_router)
 api_router.include_router(admin_payments_router)
 api_router.include_router(social_media_router)
+api_router.include_router(teacher_app_router, tags=["teacher_applications"])
 
 # Export both routers
 __all__ = ["api_router","pages_router"]

--- a/backend/routers/pages.py
+++ b/backend/routers/pages.py
@@ -101,10 +101,23 @@ async def login_page(request: Request):
 async def logout_page(request: Request):
     return templates.TemplateResponse("logout.html", {"request": request})
 
-@router.get("/contact", name="contact")
+@router.get("/contact-us", name="contact-us")
 async def contact_page(request: Request):
-    """Render the contact page."""
-    return templates.TemplateResponse("pages/contact.html", {"request": request})
+    """Render the contact us page."""
+    return templates.TemplateResponse("pages/contact_us.html", {"request": request})
+
+@router.get("/teach", name="teach")
+async def teach_page(request: Request):
+    """Render the teach with us page."""
+    return templates.TemplateResponse("pages/teach.html", {"request": request})
+
+@router.get("/privacy-policy", name="privacy")
+async def privacy_page(request: Request):
+    return templates.TemplateResponse("pages/privacy_policy.html", {"request": request})
+
+@router.get("/terms", name="terms")
+async def terms_page(request: Request):
+    return templates.TemplateResponse("pages/terms.html", {"request": request})
 
 ## 3.6 Admin Dashboard Route
 @router.get("/admin/dashboard")

--- a/backend/routers/teacher_application.py
+++ b/backend/routers/teacher_application.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+from backend.core.database import get_db
+from backend.pydanticschemas.teacher_application import TeacherApplicationCreate
+from backend.crud.teacher_application import crud_teacher_application
+
+router = APIRouter()
+
+@router.post("/teacher-applications", status_code=status.HTTP_201_CREATED)
+def submit_application(data: TeacherApplicationCreate, db: Session = Depends(get_db)):
+    """Create a teacher application."""
+    return crud_teacher_application.create(db, obj_in=data)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -83,3 +83,13 @@ def test_create_scheduled_post():
     assert response.status_code in (201, 403, 401)
 
 
+def test_teacher_application():
+    data = {
+        "full_name": "Jane Doe",
+        "email": "jane@example.com",
+        "phone": "08000000000",
+        "message": "I would like to teach."}
+    response = client.post("/teacher-applications", json=data)
+    assert response.status_code in (201, 422)
+
+

--- a/frontend/templates/pages/contact_us.html
+++ b/frontend/templates/pages/contact_us.html
@@ -1,5 +1,5 @@
 {% extends 'layout/base.html' %}
-{% block title %}TechKids | Contact{% endblock %}
+{% block title %}TechKids | Contact Us{% endblock %}
 {% block content %}
 <section class="py-5">
   <div class="container">

--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -39,7 +39,7 @@
       <div class="carousel-caption position-absolute top-50 start-50 translate-middle text-center">
         <h2>Hands-On Experience</h2>
         <p>Interactive projects that spark creativity.</p>
-        <a href="/contact" class="btn btn-primary mt-3 px-4 py-2">
+        <a href="/contact-us" class="btn btn-primary mt-3 px-4 py-2">
             Contact Us
           </a>
       </div>

--- a/frontend/templates/pages/privacy_policy.html
+++ b/frontend/templates/pages/privacy_policy.html
@@ -1,0 +1,16 @@
+{% extends 'layout/base.html' %}
+{% block title %}TechKids | Privacy Policy{% endblock %}
+{% block content %}
+<section class="py-5">
+  <div class="container">
+    <h2 class="text-center mb-4">Privacy Policy</h2>
+    <p>This Privacy Policy explains how TechKids collects, uses, and protects your personal information. We comply with the Nigeria Data Protection Regulation (NDPR) and other applicable laws.</p>
+    <h5>Information We Collect</h5>
+    <p>We collect personal details such as your name, email, phone number, and any other information you provide when you register or contact us.</p>
+    <h5>How We Use Your Information</h5>
+    <p>Your information is used to manage registrations, process payments, communicate with you, and improve our services. We do not share your data with third parties except as required by law.</p>
+    <h5>Your Rights</h5>
+    <p>You may request access to, or deletion of, your personal data by contacting us at <a href="mailto:techkids@ungozu.com">techkids@ungozu.com</a>.</p>
+  </div>
+</section>
+{% endblock %}

--- a/frontend/templates/pages/teach.html
+++ b/frontend/templates/pages/teach.html
@@ -1,0 +1,29 @@
+{% extends 'layout/base.html' %}
+{% block title %}TechKids | Teach With Us{% endblock %}
+{% block content %}
+<section class="py-5">
+  <div class="container">
+    <h2 class="text-center mb-4">Teach With Us</h2>
+    <p class="text-center mb-4">Fill the form below to apply as an instructor.</p>
+    <form action="/api/teacher-applications" method="post" class="mx-auto" style="max-width:600px;">
+      <div class="mb-3">
+        <label for="full_name" class="form-label">Full Name</label>
+        <input type="text" class="form-control" id="full_name" name="full_name" required>
+      </div>
+      <div class="mb-3">
+        <label for="email" class="form-label">Email</label>
+        <input type="email" class="form-control" id="email" name="email" required>
+      </div>
+      <div class="mb-3">
+        <label for="phone" class="form-label">Phone</label>
+        <input type="text" class="form-control" id="phone" name="phone">
+      </div>
+      <div class="mb-3">
+        <label for="message" class="form-label">Message</label>
+        <textarea class="form-control" id="message" name="message" rows="4"></textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">Submit Application</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/frontend/templates/pages/terms.html
+++ b/frontend/templates/pages/terms.html
@@ -1,0 +1,11 @@
+{% extends 'layout/base.html' %}
+{% block title %}TechKids | Terms of Use{% endblock %}
+{% block content %}
+<section class="py-5">
+  <div class="container">
+    <h2 class="text-center mb-4">Terms of Use</h2>
+    <p>By using the TechKids website, you agree to abide by these terms. Our courses and resources are provided for educational purposes. Users are expected to respect intellectual property rights and refrain from any unlawful activity.</p>
+    <p>Payments made for courses are non-refundable once access has been granted. We may update these terms from time to time. Nigerian law governs these terms and any disputes will be resolved in the courts of Nigeria.</p>
+  </div>
+</section>
+{% endblock %}

--- a/frontend/templates/partials/footer.html
+++ b/frontend/templates/partials/footer.html
@@ -3,9 +3,10 @@
         <ul class="list-inline mb-2">
             <li class="list-inline-item"><a href="#about">About</a></li>
             <li class="list-inline-item"><a href="#courses">Courses</a></li>
-            <li class="list-inline-item"><a href="#teach">Teach With Us</a></li>
-            <li class="list-inline-item"><a href="#privacy">Privacy Policy</a></li>
-            <li class="list-inline-item"><a href="#terms">Terms</a></li>
+            <li class="list-inline-item"><a href="/teach">Teach With Us</a></li>
+            <li class="list-inline-item"><a href="/privacy-policy">Privacy Policy</a></li>
+            <li class="list-inline-item"><a href="/terms">Terms</a></li>
+            <li class="list-inline-item"><a href="/contact-us">Contact Us</a></li>
         </ul>
         <p class="mb-0">🇳🇬 Nigeria | 🌍 Global Access</p>
         <p class="mb-0">Powered by Ungozu &amp; Sons Enterprises Limited</p>

--- a/frontend/templates/partials/navbar.html
+++ b/frontend/templates/partials/navbar.html
@@ -23,10 +23,10 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == '/contact' }}"
-                           href="/contact"
-                           aria-current="{{ 'page' if request.url.path == '/contact' }}">
-                            Contact
+                        <a class="nav-link {{ 'active' if request.url.path == '/contact-us' }}"
+                           href="/contact-us"
+                           aria-current="{{ 'page' if request.url.path == '/contact-us' }}">
+                            Contact Us
                         </a>
                     </li>
                     {% if request.cookies.access_token %}


### PR DESCRIPTION
## Summary
- rename Contact page to `contact-us` and update navbar/footer references
- add teacher application feature with database model and API route
- create `Teach With Us`, `Privacy Policy`, and `Terms of Use` pages
- link new pages in footer and update hero button
- test teacher application API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845871c3294833297c419a73da349fc