### PR TITLE
Fix missing DB tables on startup

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -27,3 +27,7 @@ def get_db():
         yield db
     finally:
         db.close()
+
+def init_db() -> None:
+    """Create all database tables if they don't exist."""
+    Base.metadata.create_all(bind=engine)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import uvicorn
 from backend.middleware import blacklist_middleware
 from backend.routers import api_router, pages_router
 from backend.services.social_scheduler import start_scheduler
+from backend.core.database import init_db
 
 logging.basicConfig(
     level=logging.INFO,
@@ -70,6 +71,7 @@ app.include_router(pages_router)
 @app.on_event("startup")
 def start_background_tasks() -> None:
     """Start recurring schedulers."""
+    init_db()
     start_scheduler()
 
 


### PR DESCRIPTION
## Summary
- ensure database tables exist by default
- run DB init when the app starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684593a2e77483328ef5bce4d7987fab