### PR TITLE
Fix testimonial toggle and add deletion

### DIFF
--- a/backend/crud/testimonial.py
+++ b/backend/crud/testimonial.py
@@ -31,4 +31,16 @@ class CRUDTestimonial:
         db.refresh(record)
         return record
 
+    def delete(self, db: Session, testimonial_id: int) -> Testimonial:
+        record = db.query(self.model).filter(self.model.id == testimonial_id).first()
+        if not record:
+            raise HTTPException(status_code=404, detail="Testimonial not found")
+        db.delete(record)
+        try:
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))
+        return record
+
 crud_testimonial = CRUDTestimonial(Testimonial)

--- a/backend/routers/testimonial.py
+++ b/backend/routers/testimonial.py
@@ -27,3 +27,11 @@ def update_testimonial(testimonial_id: int, data: TestimonialUpdate, db: Session
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
     return crud_testimonial.update(db, testimonial_id, data)
+
+
+@router.delete("/admin/testimonials/{testimonial_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_testimonial(testimonial_id: int, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    crud_testimonial.delete(db, testimonial_id)
+    return {"detail": f"Testimonial {testimonial_id} deleted"}

--- a/frontend/static/js/pages/manage_testimonials.js
+++ b/frontend/static/js/pages/manage_testimonials.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.approve-btn').forEach(btn => {
         btn.addEventListener('click', async () => {
             const id = btn.dataset.id;
-            const approved = btn.dataset.approved === 'true';
+            const approved = (btn.dataset.approved || '').toLowerCase() === 'true';
             const res = await fetch(`/api/admin/testimonials/${id}`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
@@ -12,6 +12,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 location.reload();
             } else {
                 alert('Failed to update testimonial');
+            }
+        });
+    });
+
+    document.querySelectorAll('.delete-testimonial').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+            e.preventDefault();
+            const id = btn.dataset.id;
+            if (confirm('Are you sure you want to delete this testimonial?')) {
+                const res = await fetch(`/api/admin/testimonials/${id}`, {
+                    method: 'DELETE'
+                });
+                if (res.ok) {
+                    location.reload();
+                } else {
+                    alert('Failed to delete testimonial');
+                }
             }
         });
     });

--- a/frontend/templates/admin/manage_testimonials.html
+++ b/frontend/templates/admin/manage_testimonials.html
@@ -26,6 +26,7 @@
                 <td>{{ 'Yes' if t.is_approved else 'No' }}</td>
                 <td>
                     <button class="btn btn-sm btn-primary approve-btn" data-id="{{ t.id }}" data-approved="{{ t.is_approved }}">Toggle Approval</button>
+                    <a href="" class="btn btn-sm btn-danger delete-testimonial" data-id="{{ t.id }}">Delete</a>
                 </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- ensure manage testimonials page parses approved flag properly
- allow admins to delete testimonials
- enable backend CRUD delete logic and endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845979949a48332ae7a677ae6704231