### PR TITLE
Fix filtering and form handling, add course details

### DIFF
--- a/backend/crud/course.py
+++ b/backend/crud/course.py
@@ -99,6 +99,20 @@ class CRUDCourse:
         )
         return result[0] if result else None
 
+    def get_top_courses(
+        self, db: Session, limit: int = 3, exclude_course_id: int | None = None
+    ) -> List[Course]:
+        query = (
+            db.query(self.model, func.count(Registration.id).label("c"))
+            .outerjoin(Registration, Registration.course_id == self.model.id)
+            .group_by(self.model.id)
+            .order_by(func.count(Registration.id).desc())
+        )
+        if exclude_course_id is not None:
+            query = query.filter(self.model.id != exclude_course_id)
+        results = query.limit(limit).all()
+        return [r[0] for r in results]
+
     def update(self, db: Session, course_id: int, obj_in: CourseCreate) -> Course:
         """
         Update a Course by ID.

--- a/backend/routers/course.py
+++ b/backend/routers/course.py
@@ -39,18 +39,20 @@ def get_courses(
     search: str | None = None,
     category: str | None = None,
     age: str | None = None,
-    price_min: float | None = None,
-    price_max: float | None = None,
+    price_min: str | None = None,
+    price_max: str | None = None,
 ):
     """Retrieve courses with optional filtering."""
-    if search or category or age or price_min is not None or price_max is not None:
+    price_min_val = float(price_min) if price_min not in (None, "") else None
+    price_max_val = float(price_max) if price_max not in (None, "") else None
+    if search or category or age or price_min_val is not None or price_max_val is not None:
         return crud_course.get_filtered(
             db=db,
             search=search,
             category=category,
             age=age,
-            price_min=price_min,
-            price_max=price_max,
+            price_min=price_min_val,
+            price_max=price_max_val,
         )
     return crud_course.get_all(db=db, skip=skip, limit=limit)
 

--- a/backend/routers/teacher_application.py
+++ b/backend/routers/teacher_application.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, Request
 from sqlalchemy.orm import Session
 from backend.core.database import get_db
 from backend.pydanticschemas.teacher_application import TeacherApplicationCreate
@@ -7,6 +7,12 @@ from backend.crud.teacher_application import crud_teacher_application
 router = APIRouter()
 
 @router.post("/teacher-applications", status_code=status.HTTP_201_CREATED)
-def submit_application(data: TeacherApplicationCreate, db: Session = Depends(get_db)):
-    """Create a teacher application."""
+async def submit_application(request: Request, db: Session = Depends(get_db)):
+    """Create a teacher application from JSON or form data."""
+    if request.headers.get("content-type", "").startswith("application/json"):
+        payload = await request.json()
+    else:
+        form = await request.form()
+        payload = dict(form)
+    data = TeacherApplicationCreate(**payload)
     return crud_teacher_application.create(db, obj_in=data)

--- a/frontend/templates/pages/course_detail.html
+++ b/frontend/templates/pages/course_detail.html
@@ -1,0 +1,20 @@
+{% extends 'layout/base.html' %}
+{% block title %}TechKids | {{ course.title }}{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <div class="row align-items-center">
+    <div class="col-md-6 mb-3 mb-md-0">
+      <img src="{{ course.image_url }}" alt="{{ course.title }}" class="img-fluid rounded">
+    </div>
+    <div class="col-md-6">
+      <h2 class="mb-3">{{ course.title }}</h2>
+      <p class="mb-3">{{ course.description }}</p>
+      <p class="fw-semibold text-secondary mb-1"><i class="bi bi-tag-fill"></i> Category: {{ course.category }}</p>
+      <p class="fw-semibold text-secondary mb-1"><i class="bi bi-person-fill"></i> Age Group: {{ course.age_group }}</p>
+      <p class="fw-semibold text-secondary mb-1"><i class="bi bi-clock-fill"></i> Duration: {{ course.duration }}</p>
+      <p class="fw-bold text-success fs-5 mt-2"><i class="bi bi-cash-coin"></i> ₦{{ "{:,.0f}".format(course.price) }}</p>
+      <a href="/registration?course={{ course.id }}" class="btn btn-primary">Register Now</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -61,6 +61,7 @@
 <!-- =======================
      ABOUT US
 ======================= -->
+{% if not (request.query_params.get('search') or request.query_params.get('category') or request.query_params.get('age') or request.query_params.get('price_min') or request.query_params.get('price_max')) %}
 <section id="about" class="py-5 about-section">
   <div class="container">
     <div class="row align-items-center">
@@ -92,6 +93,7 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 <!-- =======================
      HERO COURSE

--- a/frontend/templates/partials/course_card.html
+++ b/frontend/templates/partials/course_card.html
@@ -25,7 +25,8 @@
     <i class="bi bi-cash-coin"></i> ₦{{ "{:,.0f}".format(course.price) }}
   </p>
 
-  <a href="/registration?course={{ course.id }}" class="btn btn-primary mt-auto">
+  <a href="/registration?course={{ course.id }}" class="btn btn-primary mt-auto mb-2">
     <i class="bi bi-pencil-square me-1"></i> Register Now
   </a>
-</div> 
+  <a href="/courses/{{ course.id }}" class="btn btn-outline-primary">View Details</a>
+</div>


### PR DESCRIPTION
## Summary
- parse course filters safely when query params are empty
- compute top courses by registrations on the home page
- allow `teacher-applications` endpoint to accept JSON or form data
- hide About Us section when viewing filtered courses
- add course detail page and view details link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bedd4b0c83328b3a1440520ba15e