### PR TITLE
Improve age filtering and sticky filter visibility

### DIFF
--- a/backend/crud/course.py
+++ b/backend/crud/course.py
@@ -82,7 +82,8 @@ class CRUDCourse:
         if category:
             query = query.filter(self.model.category == category)
         if age:
-            query = query.filter(self.model.age_group == age)
+            like_age = f"%{age}%"
+            query = query.filter(self.model.age_group.ilike(like_age))
         if price_min is not None:
             query = query.filter(self.model.price >= price_min)
         if price_max is not None:

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -130,4 +130,5 @@ body {
   position: sticky;
   top: 20px;
   z-index: 100;
+  align-self: flex-start;
 }


### PR DESCRIPTION
## Summary
- support partial matches when filtering courses by age group
- keep the course filter sidebar fixed while scrolling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c6c8d41883329c4b83ce4ae60faa