### PR TITLE
Improve form feedback messages

### DIFF
--- a/frontend/static/js/pages/teacher_application.js
+++ b/frontend/static/js/pages/teacher_application.js
@@ -1,7 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById('testimonialForm');
-    const successBox = document.getElementById('testimonialSuccess');
-    const errorBox = document.getElementById('testimonialError');
+    const form = document.getElementById('teacherApplicationForm');
+    if (!form) return;
+    const successBox = document.getElementById('teachSuccess');
+    const errorBox = document.getElementById('teachError');
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -12,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = Object.fromEntries(formData.entries());
 
         try {
-            const res = await fetch('/api/testimonials', {
+            const res = await fetch('/api/teacher-applications', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(data)
@@ -21,7 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 form.reset();
                 successBox.classList.remove('d-none');
             } else {
-                throw new Error('Failed to submit testimonial.');
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.detail || 'Failed to submit application.');
             }
         } catch (err) {
             errorBox.textContent = err.message || 'Submission failed. Please try again later.';

--- a/frontend/templates/pages/teach.html
+++ b/frontend/templates/pages/teach.html
@@ -1,11 +1,15 @@
 {% extends 'layout/base.html' %}
 {% block title %}TechKids | Teach With Us{% endblock %}
+{% block extra_head %}
+{{ super() }}
+<script src="/static/js/pages/teacher_application.js" defer></script>
+{% endblock %}
 {% block content %}
 <section class="py-5">
   <div class="container">
     <h2 class="text-center mb-4">Teach With Us</h2>
     <p class="text-center mb-4">Fill the form below to apply as an instructor.</p>
-    <form action="/api/teacher-applications" method="post" class="mx-auto" style="max-width:600px;">
+    <form id="teacherApplicationForm" class="mx-auto" style="max-width:600px;">
       <div class="mb-3">
         <label for="full_name" class="form-label">Full Name</label>
         <input type="text" class="form-control" id="full_name" name="full_name" required>
@@ -24,6 +28,8 @@
       </div>
       <button type="submit" class="btn btn-primary">Submit Application</button>
     </form>
+    <div id="teachSuccess" class="alert alert-success mt-3 d-none">Your application has been submitted successfully!</div>
+    <div id="teachError" class="alert alert-danger mt-3 d-none"></div>
   </div>
 </section>
 {% endblock %}

--- a/frontend/templates/pages/testimonial_form.html
+++ b/frontend/templates/pages/testimonial_form.html
@@ -12,6 +12,8 @@
     <h2 class="text-center mb-4">Share Your Experience</h2>
     <div class="row justify-content-center">
       <div class="col-md-6">
+        <div id="testimonialSuccess" class="alert alert-success d-none">Thank you for giving us feedback on our services. We value your feedbacks as they help us improve our services.</div>
+        <div id="testimonialError" class="alert alert-danger d-none"></div>
         <form id="testimonialForm">
           <div class="mb-3">
             <label for="name" class="form-label">Your Name</label>
@@ -23,7 +25,6 @@
           </div>
           <button type="submit" class="btn btn-primary">Submit</button>
         </form>
-        <div id="testimonialSuccess" class="alert alert-success mt-3 d-none">Thank you! Your testimonial will appear once approved.</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- improve testimonial form messages
- add error display for testimonial form submission failures
- add teach-with-us form success and error messages
- handle teacher application submissions via JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cb0780dc8332982eb5f30830dcd2