### PR TITLE
Implement course categories and preview link support

### DIFF
--- a/alembic/versions/abcdef123456_add_category_table_and_preview.py
+++ b/alembic/versions/abcdef123456_add_category_table_and_preview.py
@@ -1,0 +1,24 @@
+"""add category table and preview link"""
+
+revision = 'abcdef123456'
+down_revision = 'df1f61be6bfd'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.create_table(
+        'categories',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(length=100), nullable=False, unique=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+    op.add_column('courses', sa.Column('preview_link', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('courses', 'preview_link')
+    op.drop_table('categories')

--- a/backend/crud/category.py
+++ b/backend/crud/category.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+
+from backend.models.category import Category
+from backend.pydanticschemas.category import CategoryCreate
+
+class CRUDCategory:
+    def __init__(self, model):
+        self.model = model
+
+    def create(self, db: Session, obj_in: CategoryCreate) -> Category:
+        data = obj_in.model_dump()
+        record = self.model(**data)
+        db.add(record)
+        try:
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))
+        db.refresh(record)
+        return record
+
+    def get_all(self, db: Session):
+        return db.query(self.model).order_by(self.model.name).all()
+
+crud_category = CRUDCategory(Category)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -6,4 +6,5 @@ from backend.models.payment import Payment
 from backend.models.order import Order
 from backend.models.blacklisted_tokens import BlacklistedToken
 from backend.models.social_post import SocialMediaPost
+from backend.models.category import Category
 

--- a/backend/models/category.py
+++ b/backend/models/category.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime
+from backend.core.database import Base
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<Category(id={self.id}, name={self.name})>"

--- a/backend/models/course.py
+++ b/backend/models/course.py
@@ -16,6 +16,7 @@ class Course(Base):
     category = Column(String(100), nullable=True)
     age_group = Column(String(100), nullable=False)
     duration = Column(String(100), nullable=False)
+    preview_link = Column(String(255), nullable=True)
     rating = Column(Float, default=0.0, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/pydanticschemas/category.py
+++ b/backend/pydanticschemas/category.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+class CategoryBase(BaseModel):
+    name: str = Field(..., max_length=100)
+
+class CategoryCreate(CategoryBase):
+    pass
+
+class CategorySchema(CategoryBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/pydanticschemas/course.py
+++ b/backend/pydanticschemas/course.py
@@ -13,6 +13,7 @@ class CourseBase(BaseModel):
     category: str | None = Field(None, max_length=100, description="Course category")
     age_group: str = Field(..., max_length=50, description="Age group the course is designed for")
     duration: str = Field(..., max_length=100, description="Course duration (e.g., '6 weeks')")
+    preview_link: str | None = Field(None, max_length=255, description="Link to preview class")
     rating: Optional[float] = Field(0.0, ge=0.0, le=5.0, description="Course rating (0 to 5 stars)")
 
     def model_dump(self, **kwargs):
@@ -39,6 +40,7 @@ class CourseUpdate(BaseModel):
     category: Optional[str] = Field(None, max_length=100, description="Course category")
     age_group: Optional[str] = Field(None, max_length=100, description="Age group the course is designed for")
     duration: Optional[str] = Field(None, max_length=100, description="Course duration (e.g., '6 weeks')")
+    preview_link: Optional[str] = Field(None, max_length=255, description="Link to preview class")
     rating: Optional[float] = Field(None, ge=0.0, le=5.0, description="Course rating (0 to 5 stars)")
     # = Field(None, max_length=50, description="Age group the course is designed for")
 

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -13,6 +13,7 @@ from backend.routers.admin_payments import router as admin_payments_router
 from backend.routers.social_media import router as social_media_router
 from backend.routers.teacher_application import router as teacher_app_router
 from backend.routers.testimonial import router as testimonial_router
+from backend.routers.category import router as category_router
 
 # API Router for backend endpoints
 api_router = APIRouter()
@@ -30,6 +31,7 @@ api_router.include_router(admin_payments_router)
 api_router.include_router(social_media_router)
 api_router.include_router(teacher_app_router, tags=["teacher_applications"])
 api_router.include_router(testimonial_router, tags=["testimonials"])
+api_router.include_router(category_router)
 
 # Export both routers
 __all__ = ["api_router","pages_router"]

--- a/backend/routers/admin_courses.py
+++ b/backend/routers/admin_courses.py
@@ -49,8 +49,10 @@ async def add_course(
     title: str = Form(...),
     description: str = Form(...),
     price: float = Form(...),
+    category: str | None = Form(None),
     age_group: str = Form(...),
     duration: str = Form(...),
+    preview_link: str | None = Form(None),
     rating: Optional[float] = Form(0.0),
     image_url: Optional[str] = Form(None),
     image_file: Optional[UploadFile] = File(None),
@@ -95,8 +97,10 @@ async def add_course(
         "title": title,
         "description": description,
         "price": price,
+        "category": category,
         "age_group": age_group,
         "duration": duration,
+        "preview_link": preview_link,
         "rating": rating,
         "image_url": image_url,
     }
@@ -128,8 +132,10 @@ async def update_course(
     title: str = Form(None),
     description: str = Form(None),
     price: float = Form(None),
+    category: str = Form(None),
     age_group: str = Form(None),
     duration: str = Form(None),
+    preview_link: str = Form(None),
     image: UploadFile = File(None),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
@@ -148,12 +154,18 @@ async def update_course(
         
     if price:
         db_course.price = price
-        
+
+    if category is not None:
+        db_course.category = category
+
     if age_group:
         db_course.age_group = age_group
         
     if duration:
         db_course.duration = duration
+
+    if preview_link is not None:
+        db_course.preview_link = preview_link
 
     if image:
         upload_dir = os.path.join("frontend/static", "uploads")

--- a/backend/routers/category.py
+++ b/backend/routers/category.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.crud.category import crud_category
+from backend.pydanticschemas.category import CategoryCreate, CategorySchema
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+@router.get("/", response_model=list[CategorySchema])
+def list_categories(db: Session = Depends(get_db)):
+    return crud_category.get_all(db)
+
+@router.post("/", response_model=CategorySchema, status_code=status.HTTP_201_CREATED)
+def add_category(data: CategoryCreate, db: Session = Depends(get_db)):
+    return crud_category.create(db, obj_in=data)

--- a/backend/routers/pages.py
+++ b/backend/routers/pages.py
@@ -441,6 +441,16 @@ async def add_course_page(request: Request, user: User = Depends(get_current_use
         raise HTTPException(status_code=403, detail="Admin access required")
     return templates.TemplateResponse("admin/add_course.html", {"request": request, "current_user": user})
 
+@router.get("/admin/add-category", name="add_category_form")
+async def add_category_page(request: Request, user: User = Depends(get_current_user)):
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return templates.TemplateResponse("admin/add_category.html", {"request": request, "current_user": user})
+
+@router.get("/instructor-profile", name="instructor_profile")
+def instructor_profile_page(request: Request):
+    return templates.TemplateResponse("pages/instructor_profile.html", {"request": request})
+
 @router.get("/admin/edit-course/{course_id}", name="edit_course_form")
 async def edit_course_page(request: Request, course_id: int, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     """Render the 'Edit Course' page."""

--- a/frontend/static/js/pages/add_category.js
+++ b/frontend/static/js/pages/add_category.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('addCategoryForm');
+  const btn = document.getElementById('addCategoryBtn');
+  if(!form) return;
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    btn.innerHTML = 'Adding... <span class="spinner-border spinner-border-sm" role="status"></span>';
+    const formData = new FormData(form);
+    try {
+      const res = await fetch('/api/categories/', {
+        method: 'POST',
+        body: JSON.stringify(Object.fromEntries(formData)),
+        headers: {'Content-Type': 'application/json'}
+      });
+      if(!res.ok) throw new Error('Failed');
+      form.reset();
+      btn.innerHTML = 'Add Category';
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-success mt-3';
+      alert.textContent = 'Category added';
+      form.prepend(alert);
+    } catch(err) {
+      btn.innerHTML = 'Add Category';
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-danger mt-3';
+      alert.textContent = 'Error adding category';
+      form.prepend(alert);
+    }
+  });
+});

--- a/frontend/static/js/pages/course_categories.js
+++ b/frontend/static/js/pages/course_categories.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const select = document.getElementById('category');
+  if(!select) return;
+  try {
+    const res = await fetch('/api/categories/');
+    const cats = await res.json();
+    cats.forEach(c => {
+      const opt = document.createElement('option');
+      opt.value = c.name;
+      opt.textContent = c.name;
+      if(select.dataset.selected && select.dataset.selected === c.name) {
+        opt.selected = true;
+      }
+      select.appendChild(opt);
+    });
+  } catch (e) {
+    console.error('Failed to load categories', e);
+  }
+});

--- a/frontend/templates/admin/add_category.html
+++ b/frontend/templates/admin/add_category.html
@@ -1,0 +1,28 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Admin | Add Category{% endblock %}
+
+{% block extra_head %}
+  <script src="/static/js/pages/add_category.js" defer></script>
+{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <h1 class="mb-4">Add Course Category</h1>
+      <div class="card">
+        <div class="card-body">
+          <form id="addCategoryForm">
+            <div class="mb-3">
+              <label for="name" class="form-label">Category Name</label>
+              <input type="text" class="form-control" id="name" name="name" required>
+            </div>
+            <button type="submit" class="btn btn-primary" id="addCategoryBtn">Add Category</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/frontend/templates/admin/add_course.html
+++ b/frontend/templates/admin/add_course.html
@@ -4,6 +4,7 @@
 
 {% block extra_head %}
   <script src="/static/js/pages/admin_course.js" defer></script>
+  <script src="/static/js/pages/course_categories.js" defer></script>
 {% endblock %}
 
 {% block content %}
@@ -27,12 +28,20 @@
               <input type="number" step="0.01" class="form-control" id="price" name="price" required>
             </div>
             <div class="mb-3">
+              <label for="category" class="form-label">Category</label>
+              <select class="form-select" id="category" name="category"></select>
+            </div>
+            <div class="mb-3">
               <label for="age_group" class="form-label">Age Group</label>
               <input type="text" class="form-control" id="age_group" name="age_group" required>
             </div>
             <div class="mb-3">
               <label for="duration" class="form-label">Duration</label>
               <input type="text" class="form-control" id="duration" name="duration" required>
+            </div>
+            <div class="mb-3">
+              <label for="preview_link" class="form-label">Class Preview Link</label>
+              <input type="url" class="form-control" id="preview_link" name="preview_link">
             </div>
             <div class="mb-3">
               <label for="rating" class="form-label">Rating</label>

--- a/frontend/templates/admin/admin_edit_course.html
+++ b/frontend/templates/admin/admin_edit_course.html
@@ -4,6 +4,7 @@
 
 {% block extra_head %}
 <script src="/static/js/pages/admin_edit_course.js" defer></script>
+<script src="/static/js/pages/course_categories.js" defer></script>
 {% endblock %}
 
 {% block content %}
@@ -45,11 +46,15 @@
                 </div>
                 <div class="mb-3">
                     <label for="category" class="form-label">Category</label>
-                    <input type="text" class="form-control" id="category" name="category" value="{{ course.category }}">
+                    <select class="form-select" id="category" name="category" data-selected="{{ course.category }}"></select>
                 </div>
                 <div class="mb-3">
                     <label for="duration" class="form-label">Duration</label>
                     <input type="text" class="form-control" id="duration" name="duration" value="{{ course.duration }}" required>
+                </div>
+                <div class="mb-3">
+                    <label for="preview_link" class="form-label">Class Preview Link</label>
+                    <input type="url" class="form-control" id="preview_link" name="preview_link" value="{{ course.preview_link }}">
                 </div>
                 <button type="submit" class="btn btn-primary" id="editCourse" data-loading-text="Updating Course Details...">Update Course</button>
             </form>

--- a/frontend/templates/pages/course_add.html
+++ b/frontend/templates/pages/course_add.html
@@ -6,6 +6,7 @@
 
 {% block extra_head %}
     <script src="/static/js/pages/course_add.js" defer></script>
+    <script src="/static/js/pages/course_categories.js" defer></script>
     <!-- Make sure Bootstrap CSS/JS are loaded (usually in your base.html) -->
 {% endblock %}
 

--- a/frontend/templates/pages/course_detail.html
+++ b/frontend/templates/pages/course_detail.html
@@ -12,6 +12,9 @@
       <p class="fw-semibold text-secondary mb-1"><i class="bi bi-tag-fill"></i> Category: {{ course.category }}</p>
       <p class="fw-semibold text-secondary mb-1"><i class="bi bi-person-fill"></i> Age Group: {{ course.age_group }}</p>
       <p class="fw-semibold text-secondary mb-1"><i class="bi bi-clock-fill"></i> Duration: {{ course.duration }}</p>
+      <p class="fw-semibold text-secondary mb-1"><i class="bi bi-star-fill text-warning"></i> Rating: {{ course.rating }}</p>
+      <p class="fw-semibold text-secondary mb-1"><i class="bi bi-play-circle"></i> <a href="{{ course.preview_link }}" target="_blank">Class Preview</a></p>
+      <p class="fw-semibold text-secondary mb-3"><i class="bi bi-person-video3"></i> <a href="/instructor-profile">Instructor Profile</a></p>
       <p class="fw-bold text-success fs-5 mt-2"><i class="bi bi-cash-coin"></i> ₦{{ "{:,.0f}".format(course.price) }}</p>
       <a href="/registration?course={{ course.id }}" class="btn btn-primary">Register Now</a>
     </div>

--- a/frontend/templates/pages/instructor_profile.html
+++ b/frontend/templates/pages/instructor_profile.html
@@ -1,0 +1,8 @@
+{% extends 'layout/base.html' %}
+{% block title %}Instructor Profile{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h2>Instructor Profile</h2>
+  <p>This is a placeholder profile page.</p>
+</div>
+{% endblock %}

--- a/frontend/templates/partials/course_form.html
+++ b/frontend/templates/partials/course_form.html
@@ -25,7 +25,7 @@
 
   <div class="mb-3">
     <label for="courseCategory" class="form-label">Category</label>
-    <input type="text" class="form-control" id="courseCategory" name="category">
+    <select class="form-select" id="courseCategory" name="category"></select>
     <span class="text-danger small" id="categoryError"></span>
   </div>
 
@@ -39,6 +39,10 @@
     <label for="courseDuration" class="form-label">Duration</label>
     <input type="text" class="form-control" id="courseDuration" name="duration" required>
     <span class="text-danger small" id="durationError"></span>
+  </div>
+  <div class="mb-3">
+    <label for="previewLink" class="form-label">Class Preview Link</label>
+    <input type="url" class="form-control" id="previewLink" name="preview_link">
   </div>
 
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- add database model and CRUD for categories
- create category API routes and admin form
- load categories dynamically in course forms
- support preview video link in courses
- enhance course detail page with preview, rating and instructor profile link
- include minimal instructor profile placeholder page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cf772a2c8332be312512680e4b58