### PR TITLE
Add course summary and admin improvements

### DIFF
--- a/alembic/versions/b8a7e7f1ca90_add_course_summary.py
+++ b/alembic/versions/b8a7e7f1ca90_add_course_summary.py
@@ -1,0 +1,23 @@
+"""add course summary field
+
+Revision ID: b8a7e7f1ca90
+Revises: df1f61be6bfd
+Create Date: 2025-07-10 00:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8a7e7f1ca90'
+down_revision: Union[str, None] = 'df1f61be6bfd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('courses', sa.Column('summary', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('courses', 'summary')

--- a/backend/models/course.py
+++ b/backend/models/course.py
@@ -11,6 +11,7 @@ class Course(Base):
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String(255), nullable=False)
     image_url = Column(String(255), nullable=True)
+    summary = Column(Text, nullable=True)
     description = Column(Text, nullable=False)
     price = Column(Float, nullable=False)
     category = Column(String(100), nullable=True)

--- a/backend/pydanticschemas/course.py
+++ b/backend/pydanticschemas/course.py
@@ -8,6 +8,7 @@ from uuid import UUID
 class CourseBase(BaseModel):
     title: str = Field(..., max_length=255, description="Title of the course")
     image_url: Optional[str] = Field(None, description="Image URL of the course")
+    summary: Optional[str] = Field(None, description="Short summary for previews")
     description: str = Field(..., description="Detailed description of the course")
     price: float = Field(..., gt=0, description="Price of the course in USD")
     category: str | None = Field(None, max_length=100, description="Course category")
@@ -36,6 +37,7 @@ class CourseUpdate(BaseModel):
     title: Optional[str] = Field(None, max_length=255, description="Title of the course")
     image_url: Optional[str] = Field(None, description="Image URL of the course")
     description: Optional[str] = Field(None, description="Detailed description of the course")
+    summary: Optional[str] = Field(None, description="Short summary for previews")
     price: Optional[float] = Field(None, gt=0, description="Price of the course in USD")
     category: Optional[str] = Field(None, max_length=100, description="Course category")
     age_group: Optional[str] = Field(None, max_length=100, description="Age group the course is designed for")

--- a/backend/routers/admin_courses.py
+++ b/backend/routers/admin_courses.py
@@ -48,6 +48,7 @@ os.makedirs(UPLOAD_DIR, exist_ok=True)
 async def add_course(
     title: str = Form(...),
     description: str = Form(...),
+    summary: str | None = Form(None),
     price: float = Form(...),
     category: str | None = Form(None),
     age_group: str = Form(...),
@@ -66,6 +67,7 @@ async def add_course(
     Parameters:
       - title (str): Title of the course.
       - description (str): Detailed description.
+      - summary (str, optional): Short summary for previews.
       - price (float): Price of the course.
       - age_group (str): Target age group.
       - duration (str): Course duration.
@@ -96,6 +98,7 @@ async def add_course(
     course_data = {
         "title": title,
         "description": description,
+        "summary": summary,
         "price": price,
         "category": category,
         "age_group": age_group,
@@ -131,6 +134,7 @@ async def update_course(
     course_id: int,
     title: str = Form(None),
     description: str = Form(None),
+    summary: str = Form(None),
     price: float = Form(None),
     category: str = Form(None),
     age_group: str = Form(None),
@@ -151,6 +155,9 @@ async def update_course(
         
     if description:
         db_course.description = description
+
+    if summary is not None:
+        db_course.summary = summary
         
     if price:
         db_course.price = price

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -43,6 +43,7 @@ def test_create_course():
     course_data = {
         "title": "AI for Kids",
         "image_url": "https://example.com/image.jpg",
+        "summary": "A short course summary",
         "description": "Learn AI with fun exercises!",
         "price": 99.99,
         "category": "Coding",

--- a/frontend/templates/admin/add_course.html
+++ b/frontend/templates/admin/add_course.html
@@ -20,6 +20,10 @@
               <input type="text" class="form-control" id="title" name="title" required>
             </div>
             <div class="mb-3">
+              <label for="summary" class="form-label">Summary</label>
+              <textarea class="form-control" id="summary" name="summary" rows="2"></textarea>
+            </div>
+            <div class="mb-3">
               <label for="description" class="form-label">Description</label>
               <textarea class="form-control" id="description" name="description" rows="4" required></textarea>
             </div>

--- a/frontend/templates/admin/admin_edit_course.html
+++ b/frontend/templates/admin/admin_edit_course.html
@@ -21,6 +21,10 @@
                     <input type="text" class="form-control" id="title" name="title" value="{{ course.title }}" required>
                 </div>
                 <div class="mb-3">
+                    <label for="summary" class="form-label">Summary</label>
+                    <textarea class="form-control" id="summary" name="summary" rows="2">{{ course.summary }}</textarea>
+                </div>
+                <div class="mb-3">
                     <label for="image" class="form-label">Course Image</label>
                     {% if course.image_url %}
                     <img src="{{ course.image_url }}" alt="Current Course Image" style="max-width: 200px; margin-bottom: 10px;">

--- a/frontend/templates/admin/dashboard.html
+++ b/frontend/templates/admin/dashboard.html
@@ -28,6 +28,15 @@
         <div class="col-md-4">
             <div class="card">
                 <div class="card-body">
+                    <h5 class="card-title">Add Course Category</h5>
+                    <p class="card-text">Create new categories for courses.</p>
+                    <a href="/admin/add-category" class="btn btn-primary">Add Category</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
                     <h5 class="card-title">Manage Registrations</h5>
                     <p class="card-text">View course registrations and payments.</p>
                     <a href="/admin/manage-registrations" class="btn btn-primary">Go to Registrations</a>

--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -106,8 +106,9 @@
     </div>
     <div class="col-md-6">
       <h2 class="mb-3">{{ hero_course.title }}</h2>
-      <p class="mb-3">{{ hero_course.description }}</p>
-      <a href="/registration?course={{ hero_course.id }}" class="btn btn-primary">Register Now</a>
+      <p class="mb-3">{{ hero_course.summary }}</p>
+      <a href="/registration?course={{ hero_course.id }}" class="btn btn-primary me-2">Register Now</a>
+      <a href="/courses/{{ hero_course.id }}" class="btn btn-outline-primary">View Details</a>
     </div>
   </div>
 </section>
@@ -137,6 +138,7 @@
 
   <div class="row mb-4">
     <div class="col-md-3" id="courseFilter">
+      <p class="small text-muted">Use the filters below to find courses that match your interest.</p>
       <form method="get">
         <input type="text" class="form-control mb-2" name="search" placeholder="Search" value="{{ request.query_params.get('search','') }}">
         <input type="text" class="form-control mb-2" name="category" placeholder="Category" value="{{ request.query_params.get('category','') }}">

--- a/frontend/templates/partials/course_card.html
+++ b/frontend/templates/partials/course_card.html
@@ -8,7 +8,7 @@
 >
 <div class="card-body d-flex flex-column">
   <h5 class="card-title fw-semibold text-dark">{{ course.title }}</h5>
-  <p class="card-text text-muted flex-grow-1">{{ course.description }}</p>
+  <p class="card-text text-muted flex-grow-1">{{ course.summary }}</p>
 
   <p class="fw-semibold text-secondary mb-1">
     <i class="bi bi-person-fill"></i> Age Group: {{ course.age_group }}

--- a/seed.py
+++ b/seed.py
@@ -48,6 +48,7 @@ def seed_courses(db: Session, num_courses: int = 20):
         course = Course(
             title=fake.unique.catch_phrase(),
             image_url=fake.image_url() if random.choice([True, False]) else None,
+            summary=fake.sentence(nb_words=12),
             description=fake.paragraph(nb_sentences=5),
             price=round(random.uniform(50, 500), 2),
             age_group=random.choice(["Kids", "Teens", "Adults", "Seniors"]),


### PR DESCRIPTION
## Summary
- allow admins to add course categories via dashboard
- add `summary` field to courses
- show summary on course cards and hero course with View Details link
- add summary to course forms
- describe course filter form
- update tests and seed data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d85d7d9083329570424355c1d9f0