### PR TITLE
Fix upload file handling in course and social media routers

### DIFF
--- a/backend/routers/admin_courses.py
+++ b/backend/routers/admin_courses.py
@@ -82,7 +82,7 @@ async def add_course(
       HTTPException: 500 if an error occurs during file saving or DB commit.
     """
     # If an image file is provided, save it and generate its URL.
-    if image_file:
+    if image_file and image_file.filename:
         try:
             file_extension = os.path.splitext(image_file.filename)[1]
             unique_filename = f"{uuid.uuid4()}{file_extension}"
@@ -174,7 +174,7 @@ async def update_course(
     if preview_link is not None:
         db_course.preview_link = preview_link
 
-    if image:
+    if image and image.filename:
         upload_dir = os.path.join("frontend/static", "uploads")
         if not os.path.exists(upload_dir):
             os.makedirs(upload_dir)

--- a/backend/routers/social_media.py
+++ b/backend/routers/social_media.py
@@ -40,7 +40,7 @@ async def create_post(
     image_url = None
     video_url = None
 
-    if image:
+    if image and image.filename:
         file_ext = os.path.splitext(image.filename)[1]
         unique_name = f"{uuid.uuid4()}{file_ext}"
         file_path = os.path.join(UPLOAD_DIR, unique_name)
@@ -48,7 +48,7 @@ async def create_post(
             shutil.copyfileobj(image.file, buffer)
         image_url = f"/static/uploads/{unique_name}"
 
-    if video:
+    if video and video.filename:
         file_ext = os.path.splitext(video.filename)[1]
         unique_name = f"{uuid.uuid4()}{file_ext}"
         file_path = os.path.join(UPLOAD_DIR, unique_name)


### PR DESCRIPTION
## Summary
- skip processing if no file was uploaded when creating or updating a course
- handle empty file uploads for social media posts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e0da506c8332bfd9e75658e2114c