### PR TITLE
Fix missing scripts to show sections on home page

### DIFF
--- a/frontend/templates/layout/base.html
+++ b/frontend/templates/layout/base.html
@@ -66,6 +66,8 @@
     src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     crossorigin="anonymous"
   ></script>
+  <!-- Site wide scripts -->
+  <script src="/static/js/main.js" defer></script>
   <script src="/static/js/components/footer.js">
   </script>
   <script src="/static/js/components/cookie_consent.js" defer></script>


### PR DESCRIPTION
## Summary
- include `main.js` in base template so fade-in animations run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fa87c5608332aeca9b8e627377ce