### PR TITLE
Ensure mobile width for course cards

### DIFF
--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -165,7 +165,7 @@
     <div class="col-md-9">
       <div class="row">
         {% for course in courses %}
-          <div class="col-md-4 d-flex align-items-stretch mb-4">
+          <div class="col-12 col-md-4 d-flex align-items-stretch mb-4">
             <div class="card h-100 d-flex flex-column shadow course-card">
               {% include 'partials/course_card.html' %}
             </div>


### PR DESCRIPTION
## Summary
- set `col-12` for course card wrapper so cards span full width on mobile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684600209fa8833293dc73e0771f4362