### PR TITLE
Fix hero carousel overflow on mobile

### DIFF
--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -102,17 +102,31 @@ h2 {
 
 /* Mobile adjustments for hero carousel */
 @media (max-width: 576px) {
+  .carousel-img {
+    height: 400px;
+  }
+
+  .carousel-caption {
+    top: auto;
+    bottom: 15%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
   .carousel-caption h2 {
     font-size: 1.5rem !important;
     margin-top: 0 !important;
   }
+
   .carousel-caption p {
     font-size: 1rem;
   }
+
   .carousel-caption a.btn {
     font-size: 0.875rem;
     padding: 0.4rem 0.75rem;
   }
+
   .carousel-caption .overlay {
     padding: 0.75rem 1rem;
     width: 100%;

--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -163,7 +163,7 @@
       </form>
     </div>
     <div class="col-md-9">
-      <div class="row">
+      <div class="row gx-0">
         {% for course in courses %}
           <div class="col-12 col-md-4 d-flex align-items-stretch mb-4">
             <div class="card h-100 d-flex flex-column shadow course-card">


### PR DESCRIPTION
## Summary
- tweak hero carousel position on small screens
- remove horizontal gutter from course cards row

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68460efc32288332931d17b624cf2d67