### PR TITLE
Fix course card spacing

### DIFF
--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -163,7 +163,7 @@
       </form>
     </div>
     <div class="col-md-9">
-      <div class="row gx-0">
+      <div class="row g-4">
         {% for course in courses %}
           <div class="col-12 col-md-4 d-flex align-items-stretch mb-4">
             <div class="card h-100 d-flex flex-column shadow course-card">


### PR DESCRIPTION
## Summary
- fix row gap class so course cards have consistent spacing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684611ea32bc833290e2aa012b488fb5