### PR TITLE
Fix emoji flags display on homepage

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -15,4 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }, { threshold: 0.1 });
 
     document.querySelectorAll('.fade-section').forEach(sec => observer.observe(sec));
+
+    if (window.twemoji) {
+        twemoji.parse(document.body);
+    }
 });

--- a/frontend/templates/layout/base.html
+++ b/frontend/templates/layout/base.html
@@ -66,6 +66,7 @@
     src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     crossorigin="anonymous"
   ></script>
+  <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
   <!-- Site wide scripts -->
   <script src="/static/js/main.js" defer></script>
   <script src="/static/js/components/footer.js">


### PR DESCRIPTION
## Summary
- add Twemoji script to base layout for consistent emoji rendering
- parse page with Twemoji on load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684618312b44833290f08b799c40751a