### PR TITLE
Improve category filter

### DIFF
--- a/frontend/templates/pages/index.html
+++ b/frontend/templates/pages/index.html
@@ -156,7 +156,7 @@
           <option value="AI">
           <option value="Web Development">
         </datalist>
-        <input type="text" class="form-control mb-2" name="category" placeholder="Category" value="{{ request.query_params.get('category','') }}">
+        <select class="form-select mb-2" id="category" name="category" data-selected="{{ request.query_params.get('category','') }}"></select>
         <input type="text" class="form-control mb-2" name="age" placeholder="Age Group" value="{{ request.query_params.get('age','') }}">
         <input type="number" step="0.01" class="form-control mb-2" name="price_max" placeholder="Max Price" value="{{ request.query_params.get('price_max','') }}">
         <button class="btn btn-primary w-100" type="submit">Apply</button>
@@ -258,6 +258,7 @@
 {% endblock %}
 {% block extra_scripts %}
   {{ super() }}
+  <script src="/static/js/pages/course_categories.js" defer></script>
   {% if filtering %}
   <script>
     document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- show categories from database on the home page filter
- load course categories via JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846598248208332aaf1e3abd983afce