### PR TITLE
Add FAQ page and restore footer links

### DIFF
--- a/backend/routers/pages.py
+++ b/backend/routers/pages.py
@@ -156,6 +156,11 @@ async def teach_page(request: Request):
     """Render the teach with us page."""
     return templates.TemplateResponse("pages/teach.html", {"request": request})
 
+@router.get("/faq", name="faq")
+async def faq_page(request: Request):
+    """Render the frequently asked questions page."""
+    return templates.TemplateResponse("pages/faq.html", {"request": request})
+
 @router.get("/privacy-policy", name="privacy")
 async def privacy_page(request: Request):
     return templates.TemplateResponse("pages/privacy_policy.html", {"request": request})

--- a/frontend/templates/pages/faq.html
+++ b/frontend/templates/pages/faq.html
@@ -1,0 +1,96 @@
+{% extends 'layout/base.html' %}
+{% block title %}TechKids | FAQ{% endblock %}
+
+{% block content %}
+<section class="py-5">
+  <div class="container">
+    <h2 class="text-center mb-4">Frequently Asked Questions</h2>
+    <div class="accordion" id="faqAccordion">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq1-heading">
+          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faq1" aria-expanded="true" aria-controls="faq1">
+            What is TechKids?
+          </button>
+        </h2>
+        <div id="faq1" class="accordion-collapse collapse show" aria-labelledby="faq1-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            TechKids empowers young minds with technology skills through fun, hands-on courses offered both online and in person.
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq2-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq2" aria-expanded="false" aria-controls="faq2">
+            How do I register for a course?
+          </button>
+        </h2>
+        <div id="faq2" class="accordion-collapse collapse" aria-labelledby="faq2-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            Visit our <a href="/registration">registration page</a>, choose the courses that interest you and complete the simple form to get started.
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq3-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq3" aria-expanded="false" aria-controls="faq3">
+            Who can join TechKids?
+          </button>
+        </h2>
+        <div id="faq3" class="accordion-collapse collapse" aria-labelledby="faq3-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            Our programs are open to kids of all ages. Parents, teachers and organisations can also create accounts to register or manage learners.
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq4-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq4" aria-expanded="false" aria-controls="faq4">
+            Can I learn online?
+          </button>
+        </h2>
+        <div id="faq4" class="accordion-collapse collapse" aria-labelledby="faq4-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            Yes. We offer both online and in-person classes so you can learn wherever you are most comfortable.
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq5-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq5" aria-expanded="false" aria-controls="faq5">
+            How do I share feedback?
+          </button>
+        </h2>
+        <div id="faq5" class="accordion-collapse collapse" aria-labelledby="faq5-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            You can submit a testimonial using the <a href="/testimonial">Share Your Experience</a> form. We value your feedback!
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq6-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq6" aria-expanded="false" aria-controls="faq6">
+            I want to teach with TechKids. What should I do?
+          </button>
+        </h2>
+        <div id="faq6" class="accordion-collapse collapse" aria-labelledby="faq6-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            Head over to the <a href="/teach">Teach With Us</a> page and fill out the application form to join our team of instructors.
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="faq7-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq7" aria-expanded="false" aria-controls="faq7">
+            How can I contact support?
+          </button>
+        </h2>
+        <div id="faq7" class="accordion-collapse collapse" aria-labelledby="faq7-heading" data-bs-parent="#faqAccordion">
+          <div class="accordion-body">
+            You can reach us via the <a href="/contact-us">contact page</a> or through the contact section on our home page.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/frontend/templates/partials/footer.html
+++ b/frontend/templates/partials/footer.html
@@ -3,6 +3,10 @@
         <ul class="list-inline mb-2 small">
             <li class="list-inline-item"><a href="/#about">About</a></li>
             <li class="list-inline-item"><a href="/#courses">Courses</a></li>
+            <li class="list-inline-item"><a href="/registration">Start Learning</a></li>
+            <li class="list-inline-item"><a href="/testimonial">Share Your Experience</a></li>
+            <li class="list-inline-item"><a href="/teach">Teach With Us</a></li>
+            <li class="list-inline-item"><a href="/contact-us">Contact Us</a></li>
             <li class="list-inline-item"><a href="/faq">FAQ</a></li>
             <li class="list-inline-item"><a href="/privacy-policy">Privacy</a></li>
             <li class="list-inline-item"><a href="/terms">Terms</a></li>


### PR DESCRIPTION
## Summary
- reintroduce Teach With Us link and add more links in the footer
- create a new FAQ page with common questions about TechKids
- add routing for the FAQ page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f2206eb88332af94612249dab92e